### PR TITLE
4.0.0 릴리즈 글에서 마크다운 깨지는 부분 수정

### DIFF
--- a/articles/_posts/2015-09-08-release-v4.0.0.md
+++ b/articles/_posts/2015-09-08-release-v4.0.0.md
@@ -244,6 +244,7 @@ Other release files: http://nodejs.org/dist/v4.0.0/
 Documentation: http://nodejs.org/docs/v4.0.0/api/
 
 Shasums:
+
 ```
 -----BEGIN PGP SIGNED MESSAGE-----
 Hash: SHA1


### PR DESCRIPTION
Shasums 부분의 코드블럭이 제대로 표시 안됨
