### PR TITLE
fix all terms for TSC

### DIFF
--- a/articles/_posts/2015-04-02-help-us-reconcile-node-js-and-io-js.md
+++ b/articles/_posts/2015-04-02-help-us-reconcile-node-js-and-io-js.md
@@ -49,10 +49,10 @@ The TSC (Technical Steering Committee) is the primary governance body of what wo
 Unlike io.js where we have a mix of current TC process along with a solid governance structure in one document this charter should be as minimal as possible while also guaranteeing freedom and open governance. We want to continue to iterate on the TC process, as io.js has been for the last 4 months, and if we overload this document with the specifics of that process it will become quite difficult. We need help identifying areas and language improvements we can make in order to walk this line.
 -->
 
-# TSC 협약
-TSC(기술 운영 위원회)는 단일화된 io.js와 node.js 플랫폼의 관리의 주요한 주체가 될 것입니다. io.js에 익숙한 사람들에게는 새로운 기술위원회가 될 것이며 아마도 node.js의 핵심 커미터들뿐만 아니라 기존의 io.js TC 회원들도 받아들이게 될 것입니다.
+# 기술 결정 위원회(TSC) 협약
+기술 결정 위원회(Technical Steering Committe, TSC)는 단일화된 io.js와 node.js 플랫폼의 관리의 주요한 주체가 될 것입니다. io.js에 익숙한 사람들에게는 새로운 기술위원회가 될 것이며 아마도 node.js의 핵심 커미터들뿐만 아니라 기존의 io.js TC 회원들도 받아들이게 될 것입니다.
 
-[TSC 협약](https://github.com/joyent/nodejs-advisory-board/blob/master/governance-proposal/TSC-Charter-Draft.md)은 결국 이사회의 승인을 받게 될 것입니다. 그것은 특정한 권리(재단 이사회로부터 기술적인 의사결정의 자율성과 같은)가 그 안에 있어야 한다는 것을 의미합니다. 이 문서의 수정을 위해서는 이사회의 승인이 필요한데 이는 한번 공식화되면 변경이 어렵다는 것을 의미합니다.
+[기술 결정 위원회 협약](https://github.com/joyent/nodejs-advisory-board/blob/master/governance-proposal/TSC-Charter-Draft.md)은 결국 이사회의 승인을 받게 될 것입니다. 그것은 특정한 권리(재단 이사회로부터 기술적인 의사결정의 자율성과 같은)가 그 안에 있어야 한다는 것을 의미합니다. 이 문서의 수정을 위해서는 이사회의 승인이 필요한데 이는 한번 공식화되면 변경이 어렵다는 것을 의미합니다.
 
 하나의 문서에 견고한 관리체계와 함께 현재의 TC 프로세스가 혼재되어있는 io.js와는 달리, 이 협약은 자유와 개방된 관리를 보장하는 동시에 가능한 최소한의 내용을 포함해야 합니다. 우리는 io.js가 지난 4개월간 해왔던 것처럼 TC 프로세스를 계속 반복하길 원합니다. 그리고 우리가 이 문서에 프로세스와 관련된 세세한 규정을 지나치게 많이 담는다면, 그것은 꽤 곤란하게 될 것입니다. 우리는 이 선을 지키기 위해 지역의 식별과 언어를 개선하는 데 도움이 필요합니다.
 
@@ -65,10 +65,10 @@ In the foundation model that is being created there is a wall between the “Fou
 Certain matters are not left to the TSC (like legal issues) and are handled by the Foundation so they are not included in this document.
 -->
 
-# TSC 정책 초안
-[이 문서](https://github.com/joyent/nodejs-advisory-board/blob/master/governance-proposal/TSC-Policy-Draft.md)에서 재단 이사회가 TSC가 할 방향과 가치 그리고 범위를 비준할 것입니다.
+# 기술 결정 위원회 정책 초안
+[이 문서](https://github.com/joyent/nodejs-advisory-board/blob/master/governance-proposal/TSC-Policy-Draft.md)에서 재단 이사회가 기술 결정 위원회가 할 방향과 가치 그리고 범위를 비준할 것입니다.
 
-거기서 만들어진 재단의 모델에는 이사회와 선임된 경영진에 의해서 관리되는 "재단"과 TSC에 의해 관리되는 "프로젝트" 사이에 벽이 있습니다. 이 문서는 이사회가 TSC에게 인정해주는 부분, 그리고 TSC 방향성과 요구사항(개방성 같은)들을 서술합니다.
+거기서 만들어진 재단의 모델에는 이사회와 선임된 경영진에 의해서 관리되는 "재단"과 기술 결정 위원회에 의해 관리되는 "프로젝트" 사이에 벽이 있습니다. 이 문서는 이사회가 기술 결정 위원회에게 인정해주는 부분, 그리고 기술 결정 위원회 방향성과 요구사항(개방성 같은)들을 서술합니다.
 
-일부 문제(법적인 문제 등)는 TSC에게 남아있지 않고 재단에 의해 다루어지므로 이 문서에 포함되지 않습니다.
+일부 문제(법적인 문제 등)는 기술 결정 위원회에게 남아있지 않고 재단에 의해 다루어지므로 이 문서에 포함되지 않습니다.
 

--- a/articles/_posts/2015-08-13-4-0-is-the-new-1-0.md
+++ b/articles/_posts/2015-08-13-4-0-is-the-new-1-0.md
@@ -62,7 +62,7 @@ regular releases of io.js and node.js 0.12.x which are in use
 by the developer community.
 -->
 지난 몇 달 동안 io.js와 node.js의 거버넌스와 개발이 함께 이뤄졌다. 참여하는 모두가 합쳐진 릴리스가
-가능한 한 빨리 이뤄지길 바라면서 TSC[^1]는 개발 커뮤니티가 사용 중인 io.js와 node.js 0.12.x의
+가능한 한 빨리 이뤄지길 바라면서 기술 결정 위원회[^1]는 개발 커뮤니티가 사용 중인 io.js와 node.js 0.12.x의
 정기 릴리스를 계속해서 전담했다.
 
 <!--
@@ -127,7 +127,7 @@ to upgrade before major releases go out that affect the native module ecosystem.
 여기서 말하는 모듈의 개수는 어느 정도일까? 현재 NAN에 **직접** 의존하는 모듈은 600개
 정도이다(전체 npm 모듈의 0.5% 수준). 하지만 이 모듈에 대한 의존성까지 모두 계산한다면 전체 모듈의
 최대 30% 정도가 간접적으로 NAN에 의존하고 있다. 이러한 모듈이 새 버전을 좇아오려면 어느 정도 시간이
-걸릴 것이므로, TSC는 네이티브 모듈 생태계에 영향을 줄 수 있는 메이저 버전을 릴리스하기 전에
+걸릴 것이므로, 기술 결정 위원회는 네이티브 모듈 생태계에 영향을 줄 수 있는 메이저 버전을 릴리스하기 전에
 네이티브 모듈의 업그레이드를 위한 유예 시간을 늘리는 새로운 릴리스 프로세스를 개발했다.
 
 <!--
@@ -181,4 +181,4 @@ Node.js v4는 io.js 릴리스에서는 제공하지 않았던 node.js 0.12의 �
 
 이제 io.js v3를 다운로드 받고 다음의 큰 릴리스를 준비할 때이다. :)
 
-[^1]: Technical Steering Committee의 약자로 Node.js의 방향을 정하는 위원회
+[^1]: Technical Steering Committee로 Node.js의 방향을 정하는 위원회

--- a/articles/_posts/2015-09-08-release-v4.0.0.md
+++ b/articles/_posts/2015-09-08-release-v4.0.0.md
@@ -14,8 +14,8 @@ The collaborators of the Node.js project and the members of the Node.js Foundati
 Node.js 프로젝트의 협력자와 Node.js 재단의 멤버는 v4.0.0을 공식적으로 릴리스하게 되어
 자랑스럽습니다. 이제 하나의 코드로 합쳐진 Node.js와 io.js 프로젝트에서 이뤄진 수많은 시간의
 고된 작업이 이번 릴리스에 담겨 있습니다. 현재 Node.js 프로젝트는 44명의 협력자로 운영되고 있고 그중의
-15명은 Technical Steering Committee(TSC)입니다. 게다가 v0.12.7 이후 새로운 100여 명이
-코드 기여 목록에 이름을 올렸습니다.
+15명은 기술 결정 위원회(Technical Steering Committee, TSC)입니다. 게다가 v0.12.7 이후
+새로운 100여 명이 코드 기여 목록에 이름을 올렸습니다.
 
 <!--
 Node.js v4.0.0 contains V8 v4.5, the same version of V8 shipping with the Chrome web browser today. This brings with it many bonuses for Node.js users, most notably a raft of new [ES6](https://nodejs.org/en/docs/es6/) features that are enabled by default including block scoping, classes, typed arrays (Node's `Buffer` is now backed by `Uint8Array`), generators, Promises, Symbols, template strings, collections (Map, Set, etc.) and, new to V8 v4.5, arrow functions.

--- a/weekly/_posts/2015-05-29-weekly.md
+++ b/weekly/_posts/2015-05-29-weekly.md
@@ -81,7 +81,7 @@ See https://github.com/nodejs/io.js/labels/confirmed-bug for complete and curren
 ### 커뮤니티 업데이트
 
 * Rod Vaggs가 쓴 노드 커뮤니티의 [분열과 화해](https://nodesource.com/blog/was-this-trip-really-necessary)에 관한 글입니다.
-* [SoundCloud](https://soundcloud.com/node-foundation/tsc-meeting-2015-05-27)에서 첫 Node TSC 미팅을 들으실 수 있습니다.
+* [SoundCloud](https://soundcloud.com/node-foundation/tsc-meeting-2015-05-27)에서 첫 Node 기술 결정 위원회(TSC) 미팅을 들으실 수 있습니다.
 * io.js에 새로운 벤치마킹 워킹 그룹 [nodejs/benchmarking#1](https://github.com/nodejs/benchmarking/issues/1)이 생겼습니다.
 * [nodejs.com](http://blog.nodejs.org/2015/05/15/the-nodejs-foundation-benefits-all/)에 노드 재단 하의 iojs + node.js에 관한 블로그 글이 올라왔습니다.
 * io.js의 새 기여자를 위해 새로이 [`good first contribution`](https://github.com/nodejs/io.js/labels/good%20first%20contribution) 태그를 구현했습니다.

--- a/weekly/_posts/2015-09-04-weekly.md
+++ b/weekly/_posts/2015-09-04-weekly.md
@@ -75,7 +75,7 @@ See https://github.com/nodejs/node/labels/confirmed-bug for complete and current
 * Some problems with unreferenced timers running during `beforeExit` are still to be resolved. See [#1264](https://github.com/nodejs/node/issues/1264).
 * Surrogate pair in REPL can freeze terminal. [#690](https://github.com/nodejs/node/issues/690)
 * Calling `dns.setServers()` while a DNS query is in progress can cause the process to crash on a failed assertion. [#894](https://github.com/nodejs/node/issues/894)
-* `url.resolve` may transfer the auth portion of the url when resolving between two full hosts, see [#1435](https://github.com/nodejs/node/issues/1435). 
+* `url.resolve` may transfer the auth portion of the url when resolving between two full hosts, see [#1435](https://github.com/nodejs/node/issues/1435).
 -->
 
 ### 알려진 이슈
@@ -101,7 +101,7 @@ See https://github.com/nodejs/node/labels/confirmed-bug for complete and current
 <!--
 ### We are creating the list of modules that currently do not work with Node.js v4.0.0
 
-* We are listing modules that do not work with Node.js v4.0.0, If you have some troubles in your modules with Node.js v4.0.0, please provide information in this [issue](https://github.com/nodejs/node/issues/2798). 
+* We are listing modules that do not work with Node.js v4.0.0, If you have some troubles in your modules with Node.js v4.0.0, please provide information in this [issue](https://github.com/nodejs/node/issues/2798).
 -->
 
 ### 우리는 현재 Node.js v4.0.0과는 함께 작동하지 않는 모듈 리스트를 생성했습니다.
@@ -121,7 +121,7 @@ If you have spotted or written something about Node.js and io.js, do come over t
 ### 커뮤니티 업데이트
 
 * LTS 빌드를 할 V8 메인테이너를 *아직* 구하고 있습니다! [GitHub](https://github.com/nodejs/LTS/issues/28)에서 요구사항을 확인하세요.
-* Node TSC 멤버인 Jeremiah Senkpiel가 Node.js v4.0.0를 심도있게 소개했습니다. 이 [뉴스](https://medium.com/@nodesource/node-js-v4-0-0-node-at-its-best-54a93fd2e0c6)를 확인하세요.
+* Node 기술 결정 위원회(TSC) 멤버인 Jeremiah Senkpiel가 Node.js v4.0.0를 심도있게 소개했습니다. 이 [뉴스](https://medium.com/@nodesource/node-js-v4-0-0-node-at-its-best-54a93fd2e0c6)를 확인하세요.
 * Daniel Khan이 Node.js v4.0 성능, 특징 LTS에 관해 기고했습니다. [이 글](http://apmblog.dynatrace.com/2015/09/05/all-you-need-to-know-about-node-js-4-0/)은 4.0으로 옮기는데 참고가 될 것입니다.
 
 Node.js나 io.js에 관한 글을 쓰거나 발견했다면, [Evangelism 팀 저장소](https://github.com/nodejs/evangelism)에 와서 [이슈 페이지](https://github.com/nodejs/evangelism/issues)에 주간 업데이트 이슈로 알려주세요.


### PR DESCRIPTION
#132 에서 용어 통일이 어느 정도 진행된 것 같아서 기존 문서를 수정했습니다.

일단 각 문서에서 한번 정도는 "기술 결정 위원회(TSC)"식으로 약어를 같이 표시하도록 했습니다. 
