### PR TITLE
Fixed: GitHub warning for obsolete relative_permalinks option

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,6 @@ highlighter:      pygments
 
 # Permalinks
 permalink:        pretty
-relative_permalinks: true
 
 # Setup
 title:            Node.js 한국 커뮤니티


### PR DESCRIPTION
Resolve https://github.com/nodejs/nodejs-ko/issues/246
