### PR TITLE
Fix mistranslation of 2016-04-29-weekly

### DIFF
--- a/weekly/_posts/2016-04-29-weekly.md
+++ b/weekly/_posts/2016-04-29-weekly.md
@@ -35,7 +35,7 @@ See https://nodejs.org/en/blog/announcements/v6-release/ for more information.
 
 ### 세계에서 가장 빠르게 성장하는 오픈 소스 플랫폼이 새로운 릴리스를 내보내다
 
-성능 향상은 현재 Node.js 버전 4(Node.js v4)보다 네 배 빠른 모듈 로딩에서 오는 가장 중요한 개선 사항 중 하나이며 이번 최신 릴리스의 핵심입니다. 이것은 개발자에게 개발 주기와 최종 사용자가 더 원활한 체험 안에서 최상의 생산성을 위한 대규모 애플리케이션의 가동 시간을 급격히 단축하도록 도울 것입니다. 또한, Node.js v6는 ECMAScript 2015 (ES6) 지원이 향상된 v8 JavaScript 엔진 5.0이 제공됩니다. ES6 기능의 93퍼센트도 지금 Node.js v6 릴리스에서 지원되며 이는 Node.js v5에서 56퍼센트와 Node.js v4에서 50퍼센트가 오른 수치입니다. ES6의 주요 기능으로 기본 파라미터, rest 파라미터, 디스트럭처링(destructuring), class와 super 키워드 등이 있습니다.
+성능 향상은 현재 Node.js 버전 4(Node.js v4)보다 네 배 빠른 모듈 로딩에서 오는 가장 중요한 개선 사항 중 하나이며 이번 최신 릴리스의 핵심입니다. 이것은 개발자에게 개발 주기와 최종 사용자가 더 원활한 체험 안에서 최상의 생산성을 위한 대규모 애플리케이션의 가동 시간을 급격히 단축하도록 도울 것입니다. 또한, Node.js v6는 ECMAScript 2015 (ES6) 지원이 향상된 v8 JavaScript 엔진 5.0이 제공됩니다. ES6 기능의 93퍼센트도 지금 Node.js v6 릴리스에서 지원되며 이는 Node.js v5의 56퍼센트와 Node.js v4의 50퍼센트에서 향상된 수치입니다. ES6의 주요 기능으로 기본 파라미터, rest 파라미터, 디스트럭처링(destructuring), class와 super 키워드 등이 있습니다.
 
 자세한 정보는 <https://nodejs.org/en/blog/announcements/v6-release/>를 참조하십시오.
 


### PR DESCRIPTION
v5에서 56%, v4에서 50% 올랐다기보다는 v5가 56%, v4가 50% 지원하고 있었다는 쪽이 맞는 것 같아 수정했습니다.
