### PR TITLE
Fix: scaffold throws error when there's no author in source documents.

### DIFF
--- a/bin/scaffold.js
+++ b/bin/scaffold.js
@@ -1,15 +1,10 @@
 const { get } = require('https');
 const { createWriteStream } = require('fs');
+const chalk = require('chalk');
 const replaceStream = require('replacestream');
 const URL = process.argv[2];
 const DATE = process.argv[3];
 const POST_PATH = "./source/_posts/";
-
-if (!URL) {
-  console.info("A github raw url needed.");
-  console.info("\tmore info) http://nodejs.github.io/nodejs-ko/CONTRIBUTING.html");
-  return;
-}
 
 class TranslateScaffold {
   constructor(url, date) {
@@ -42,9 +37,9 @@ class TranslateScaffold {
                            (_, head) => `---
 category: weekly
 title: Node.js 주간 뉴스 ${head.match(/date: (\d{4}-\d{2}-\d{2})/)[1].replace(/-0?/, "년 ").replace(/-0?/, "월 ")}일
-author: ${head.match(/author: (.+)/)[1]}
-ref: ${head.match(/title: (.+)/)[1]}
-refurl: https://nodejs.org/en/blog/${this.url.match(/blog\/(.+)\.md/)[1]}/
+author: ${(head.match(/author: (.+)/) || [ '', '' ])[1]}
+ref: ${(head.match(/title: (.+)/) || [ '', '' ])[1]}
+refurl: https://nodejs.org/en/blog/${(this.url.match(/blog\/(.+)\.md/) || [ '', '' ])[1]} 
 translator:
 ---`)
     } else {
@@ -52,18 +47,29 @@ translator:
                            (_, head) => `---
 category: articles
 title:
-author: ${head.match(/author: (.+)/)[1]}
-ref: ${head.match(/title: (.+)/)[1]}
-refurl: https://nodejs.org/en/blog/${this.url.match(/blog\/(.+)\.md/)[1]}/
+author: ${(head.match(/author: (.+)/) || [ '', '' ])[1]}
+ref: ${(head.match(/title: (.+)/) || [ '', '' ])[1]}
+refurl: https://nodejs.org/en/blog/${(this.url.match(/blog\/(.+)\.md/) || [ '', '' ])[1]} 
 translator:
 ---`)
     }
   }
 }
 
+if (!URL) {
+  console.error(`${chalk.red.bold('Error:')} a github raw url of the source document is required.`);
+  console.error("For more information, see http://nodejs.github.io/nodejs-ko/CONTRIBUTING.html");
+  return;
+}
+
+const scaffold = new TranslateScaffold(URL, DATE);
+
+if (!scaffold.isWeekly && !DATE ) {
+	console.error(`${chalk.red.bold('Error:')} date can be omitted only for weekly updates.`);
+	return;
+}
 
 get(URL, function(response) {
-  const scaffold = new TranslateScaffold(URL, DATE);
   response
     .pipe(scaffold.replaceText)
     .pipe(scaffold.file);

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "scaffold": "node bin/scaffold.js"
   },
   "dependencies": {
+    "chalk": "^1.1.3",
     "hexo": "^3.2.0",
     "hexo-deployer-git": "^0.2.0",
     "hexo-generator-alias": "^0.1.3",


### PR DESCRIPTION
Also fix: when date isn't set for announcements, the new document name includes 'undefined'
