### PR TITLE
install hexo-cli locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
     "scaffold": "node bin/scaffold.js"
   },
   "engines": {
-    "node" : ">=4.3"
+    "node": ">=4.3"
   },
   "dependencies": {
     "chalk": "^1.1.3",
     "hexo": "^3.2.0",
+    "hexo-cli": "^1.0.2",
     "hexo-deployer-git": "hexojs/hexo-deployer-git",
     "hexo-generator-alias": "^0.1.3",
     "hexo-generator-archive": "^0.1.4",


### PR DESCRIPTION
<img width="835" alt="2016-12-17 10 28 45" src="https://cloud.githubusercontent.com/assets/390146/21287139/44629848-c4a8-11e6-882c-c1b22a7475c4.png">

최근 PR  merge 후에 사이트에서 CSS가 깨지는 현상이 발생했습니다. 아마도 [이 커밋](https://github.com/nodejs/nodejs-ko/commit/3ab2dc588b064ed5a4c722b69a26ff69a1703e49)후 배포에서 발생한 것 같고 [트위터](https://twitter.com/devthewild/status/808957721412108288)에서 이 상황에 대한 리포팅을 받았습니다.(그사이에 바빠서 이제야 처리했습니다만...)

로컬에서 `npm run deploy`로 수동으로 배포했더니 css 파일이 정상적으로 생겼습니다만 위의 3일전에도 배포가 이뤄졌는데 동일하게 css가 안생긴걸 보면 다음 배포에도 또 문제가 생길 수 있습니다. 수동으로 했을때는 문제가 없어서 스크립트 자체에는 문제가 아닌것 같은데 Lambci 에서 배포할때는 왜 문제가 생긴지 모르겠습니다. 이 문제는 @marocchino 님이 확인해 주실 수 있으신지...

이 PR은 수동으로 해보다 보니 hexo-cli 를 글로벌로 설치해야 해서 로컬에 설치한 후에 로컬에 있는 hexo-cli를 사용하도록 변경했습니다. 이부분이 Lambci에서 문제을 일으킬지도 확인 부탁드립니다.

배포는 디플로이 설정이 안되어 있다고 나와서 [PR](https://github.com/nodejs/nodejs-ko/pull/420/files)을 보고 설정에서 `repo: git@github.com:nodejs/nodejs-ko`를 임시로 지정해서 배포했습니다. `hexo-deployer-git`이 뭔가 해주는것 같은데 이게 Lambci에만 영향을 주는지 저장소를 안적어주면 로컬에서 배포가 안되더라고요. 