### PR TITLE
Translate: Node.js 8.0.0 has been delayed and will ship on or around May 30th.

### DIFF
--- a/source/_posts/2017-05-01-nodejs-8.0.0-has-been-delayed.md
+++ b/source/_posts/2017-05-01-nodejs-8.0.0-has-been-delayed.md
@@ -1,0 +1,118 @@
+---
+category: articles
+title: Node.js 8.0.0은 5월 30일경 배포될 예정입니다.
+author: Node.js Foundation
+ref: Node.js 8.0.0 has been delayed and will ship on or around May 30th
+refurl: https://medium.com/the-node-js-collection/node-js-8-0-0-has-been-delayed-and-will-ship-on-or-around-may-30th-cd38ba96980d
+translator: taggon
+---
+
+<!--
+This post is brought to you by Myles Borins who is a @nodejs ctc member / developer advocate for [@googlecloud](https://twitter.com/googlecloud). Now with that background, let’s dive into the “why” of the delay around Node.js 8.0.0.
+-->
+이 글은 [@nodejs](https://twitter.com/nodejs) 핵심 기술 위원회의 일원이자 [@googlecloud](https://twitter.com/googlecloud)의 Developer Advocate인 [Myles Borins](https://medium.com/@mylesborins)씨가 작성했습니다. Node.js 8.0.0의 출시가 "왜" 지연됐는지 살펴봅시다.
+
+<!--
+## Why? The short version
+
+We want to give ourselves the option to ship the Node.js 8.x release line with the TurboFan + Ignition pipeline, which will become the default in V8 5.9. This would allow our next LTS release line to run on a more modern compiler + jit pipeline, making backporting easier and giving us a longer support contract from the V8 team.
+-->
+## 이유? 짧은 버전
+
+우리는 V8 5.9에서 기본 사양이 되는 [TurboFan](https://github.com/v8/v8/wiki/TurboFan) + [Ignition](https://v8project.blogspot.com/2016/08/firing-up-ignition-interpreter.html) 파이프라인과 함께 Node.js 8.x 버전을 배포하려고 합니다. 이를 통해 다음 LTS 출시 라인은 더 모던한 컴파일러와 JIT 파이프라인 상에서 실행되는 한편, 백포팅도 쉬워지고 V8팀의 지원도 더 오랫동안 받을 수 있을 것입니다.
+
+<!--
+## Why? The longer version
+
+A few weeks ago I had a discussion with James Snell about the 8.0.0 release where we discovered a very unfortunate oversight. The project had decided to keep 8.0.0 on the Crankshaft and full-codegen pipeline after various meetings with the V8 team. We would land a version of V8 with the TurboFan + Ignition enable into Node.js 9.0.0. There were two primary reasons for this decision:
+
+1. Give the V8 team time to improve performance and bugs in the pipeline
+2. Offer a known and stable experience for an LTS release line
+-->
+## 이유? 긴 버전
+
+몇 주 전 저는 [James Snell](https://twitter.com/jasnell)과 함께 우리가 미처 몰랐던 문제가 발견된 8.0.0 출시에 관해 논의했습니다.
+V8팀과 몇 차례 회의 후 Node.js 프로젝트는 8.0.0 버전을 Crankshaft와 전체 codegen 파이프라인 기반을 유지하기로 정했습니다.
+TurboFan과 Ignition이 사용된 V8은 Node.js 9.0.0에 탑재하려고 했습니다. 이 같은 결정에는 두 가지 주요한 이유가 있었습니다.
+
+1. V8팀에게 새로운 파이프라인의 성능을 개선하고 버그를 제거할 시간을 줄 수 있다.
+2. LTS 출시 라인에는 널리 알려져있고 안정적인 경험을 줄 수 있다.
+
+<!--
+The oversight was the complication this would create for LTS. With V8 5.9 schedule to release in early June, Node.js 8.x would have less than two months of support from the V8 team for the old pipeline. The team has projected large ammounts of churn in the pipeline between V8 5.9 and 6.0, which would make backporting to V8 5.7 or 5.8 fairly difficult. We would find ourselves in a position where we would be shipping an unsupported version of V8 for close to 3 years. This was the first problem.
+-->
+간과했던 부분은 이 같은 결정이 LTS에 복잡한 문제를 가져올 수 있다는 점입니다.
+V8 5.9는 6월 초에 출시 예정이기 때문에 Node.js 8.x가 예전 파이프라인에 대해 V8팀으로부터 지원을 받을 수 있는 기간은 두 달도 채 안될 것입니다.
+V8팀은 V8 5.9와 6.0 사이에 매우 많은 파이프라인 관련 코드를 추가해왔으며, 이 코드는 V8 5.7과 5.8에 백포팅하기가 매우 어렵습니다.
+거의 3년간 아무런 지원도 받지 못할 V8 엔진과 함께 출시해야 하는 것입니다. 이게 첫 번째 문제입니다.
+
+<!--
+Further complicating matters was the fact that a nontrivial part of the Node.js code base had been tuned to be optimized by Crankshaft. This code has been eloquently referred to as Crankscript. If we were to wait until 9.0.0 to begin refactoring our Crankscript we would experience a fairly large delta between 8.x and 9.x very early in the life cycle of Carbon LTS.
+-->
+더 골치 아픈 문제는 Node.js 코드 베이스의 중요한 부분이 Crankshaft에 맞춰 조정되었다는 것입니다.
+이렇게 조정된 코드는 Crankscript라고 부릅니다.
+우리가 9.0.0까지 기다렸다가 Crankscript를 리팩토링한다면 같은 Carbon LTS의 관리 주기 내에 있는 8.x와 9.x 사이에서 매우 큰 차이를 경험할 것입니다.
+
+<!--
+There was also a security concern. The Chrome team does constant security audits on V8. If the project were to move forward on the old pipeline we would essentially be flying blind for 3 years.
+-->
+보안 문제도 있습니다. 크롬팀은 V8에 대해 보안 검사를 꾸준히 합니다.
+만약 Node.js 프로젝트가 예전 파이프라인을 기반으로 한다면 3년 동안은 눈뜬장님으로 지내는 셈이 됩니다.
+
+<!--
+## Some context
+
+The Argon LTS stream of Node.js (4.x) only recently went into Maintenance, which has a year of support. We are still backporting code from 7.x with relatively few conflicts. This is due to the project being very careful about introducing churn. Comparatively, if 8.x and 9.x drifted fairly quickly, backporting could prove difficult in the first few months. It would be extremely hard to imagine that code from 11.x would be able to cleanly backport to 8.x. Even worse, any changes that affected performance would likely need to be manually tested to ensure that the performance profile was consistent.
+-->
+## 맥락
+
+최근 Node.js(4.x)의 Argon LTS 스트림은 1년 동안만 지원되는 유지보수용으로 바뀌었습니다.
+상대적으로 적은 수정 사항을 아직도 7.x에서 이 출시 라인으로 백포팅하고는 있습니다.
+이 라인에는 수정 사항을 매우 조심스럽게 도입해야 하기 때문입니다.
+여기에 비추어 생각해 볼 때, 만약 8.x와 9.x 사이에서 굉장히 급격하게 변한다면 처음 몇 달간은 백포팅이 힘들 것입니다.
+11.x의 코드를 8.x로 깔끔하게 백포팅 할 수 있을 거라고는 생각하기 어렵습니다.
+더 나쁜 부분은 성능에 영향을 주는 변경 사항은 성능 프로파일이 일정한지 일일이 수작업으로 확인해야 한다는 것입니다.
+
+<!--
+## What happened next..
+
+After the conversation I had with James, I immediately started a chat with the V8 team to get their pulse on what we should do. Working with the team we put together three different plans for Node.js and V8:
+
+1. Do nothing (ship with V8 5.7)
+2. Ship on time with a version of V8 5.8 that is ABI compatible to 5.9
+3. Delay the release to allow us to ship with a version of V8 5.8 that is ABI compatible to 6.0
+
+The CTC voted in favor of delaying the release to give us the most options moving forward with the 8.x release line.
+-->
+## 그 후 진행된 일..
+
+James와 대화를 나눈 후, 저는 즉시 우리가 해야 할 일에 대한 의견을 구하기 위해 V8팀과 대화했습니다.
+V8팀과의 협업을 통해 우리는 Node.js 및 V8에 관한 [세 가지 계획](https://github.com/nodejs/CTC/issues/99#issue-221100295)을 작성했습니다.
+
+1. 아무것도 하지 않는다(V8 5.7과 함께 출시)
+2. V8 5.9와 ABI(Application Binary Interface) 호환되는 V8 5.8 버전과 함께 제때 출시한다.
+3. V8 6.0과 ABI 호환되는 V8 5.8 버전과 함께 출시할 수 있도록 출시를 미룬다.
+
+투표 결과, 핵심 기술 위원회는 8.x 출시 라인이 가장 진보할 수 있는 출시 연기를 결정했습니다.
+
+<!--
+## So what is next?
+
+We are currently testing the performance of the new pipeline and the results are promising. The V8 team is preparing special versions of 5.8 that are ABI compatible to 6.0. This will allow us to upgrade to the new pipeline as a non-breaking change, and maximize our ability to backport code to the LTS release. The 8.0.0 release will come out on or around May 30th, and unless we see any serious problems we will be able to introduce the new pipeline in early June. The LTS release date remains in October, unaffected by this delay.
+-->
+## 그래서 이제 어떻게 될 것인가?
+
+우리는 현재 새로운 파이프라인의 성능을 테스트하고 있는데 결과가 좋습니다.
+V8팀은 6.0과 ABI 호환되는 특별한 버전의 5.8을 준비하고 있습니다.
+덕분에 우리는 하위 호환을 보장하며 새로운 파이프라인으로 업그레이드할 수 있게 되었으며, LTS 출시 라인에 백포트를 적용하기도 훨씬 나아졌습니다.
+Node.js 8.0.0은 5월 30일경 출시될 예정이며 심각한 문제가 발견되지 않는다면 6월 초쯤 새로운 파이프라인을 적용할 수 있을 것입니다.
+이번 출시 지연과 관계없이 LTS의 릴리스 날짜는 그대로 10월입니다.
+
+<!--
+## Questions?
+
+There is a lot going on here. If you have any questions at all please reach out to me on Twitter.
+-->
+## 질문?
+
+여기서 많은 얘기를 했습니다. 궁금한 점이 있다면, [트위터를 통해](https://twitter.com/MylesBorins) 저에게 질문을 남겨주시기 바랍니다.

--- a/source/_posts/2017-05-01-nodejs-8.0.0-has-been-delayed.md
+++ b/source/_posts/2017-05-01-nodejs-8.0.0-has-been-delayed.md
@@ -36,13 +36,13 @@ V8팀과 몇 차례 회의 후 Node.js 프로젝트는 8.0.0 버전을 Crankshaf
 TurboFan과 Ignition이 사용된 V8은 Node.js 9.0.0에 탑재하려고 했습니다. 이 같은 결정에는 두 가지 주요한 이유가 있었습니다.
 
 1. V8팀에게 새로운 파이프라인의 성능을 개선하고 버그를 제거할 시간을 줄 수 있다.
-2. LTS 출시 라인에는 널리 알려져있고 안정적인 경험을 줄 수 있다.
+2. LTS 출시 라인에는 널리 알려져 있고 안정적인 경험을 줄 수 있다.
 
 <!--
 The oversight was the complication this would create for LTS. With V8 5.9 schedule to release in early June, Node.js 8.x would have less than two months of support from the V8 team for the old pipeline. The team has projected large ammounts of churn in the pipeline between V8 5.9 and 6.0, which would make backporting to V8 5.7 or 5.8 fairly difficult. We would find ourselves in a position where we would be shipping an unsupported version of V8 for close to 3 years. This was the first problem.
 -->
 간과했던 부분은 이 같은 결정이 LTS에 복잡한 문제를 가져올 수 있다는 점입니다.
-V8 5.9는 6월 초에 출시 예정이기 때문에 Node.js 8.x가 예전 파이프라인에 대해 V8팀으로부터 지원을 받을 수 있는 기간은 두 달도 채 안될 것입니다.
+V8 5.9는 6월 초에 출시 예정이기 때문에 Node.js 8.x가 예전 파이프라인에 대해 V8팀으로부터 지원을 받을 수 있는 기간은 두 달도 채 안 될 것입니다.
 V8팀은 V8 5.9와 6.0 사이에 매우 많은 파이프라인 관련 코드를 추가해왔으며, 이 코드는 V8 5.7과 5.8에 백포팅하기가 매우 어렵습니다.
 거의 3년간 아무런 지원도 받지 못할 V8 엔진과 함께 출시해야 하는 것입니다. 이게 첫 번째 문제입니다.
 


### PR DESCRIPTION
Resolve #562