### PR TITLE
fix broken footnotes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,8 +51,17 @@ category_map:
   - weekly
 tag_map:
 
-marked:
-  breaks: false
+# Markdown-it config
+## Docs: https://github.com/celsomiranda/hexo-renderer-markdown-it/wiki/
+markdown:
+  render:
+    html: true
+  plugins:
+    - markdown-it-abbr
+    - markdown-it-footnote
+    - markdown-it-ins
+    - markdown-it-sub
+    - markdown-it-sup
 
 feed:
   type: atom

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "hexo": {
-    "version": "3.2.2"
+    "version": "3.6.0"
   },
   "scripts": {
     "test": "echo no test",
@@ -26,7 +26,7 @@
     "hexo-generator-index": "^0.2.0",
     "hexo-generator-tag": "^0.2.0",
     "hexo-renderer-ejs": "^0.2.0",
-    "hexo-renderer-marked": "^0.2.10",
+    "hexo-renderer-markdown-it": "^3.4.1",
     "hexo-renderer-stylus": "^0.3.1",
     "hexo-server": "^0.2.0",
     "replacestream": "^4.0.0"


### PR DESCRIPTION
https://github.com/nodejs/nodejs-ko/pull/680 에 추가한 [Node.js 국제화](https://nodejs.github.io/nodejs-ko/articles/2018/01/18/internationalizing-node-js/) 글에서 예상과 달리 footnotes가 동작하지 않아서 수정했습니다.
marked 라이브러리가 지원하지 않는 것같아서 HTML로 footnotes를 넣었습니다.

직접 수정할까 하다가 footnotes 처리에 대해서 얘기해봐야 할것 같아서 PR로 올립니다. 