### PR TITLE
translate "OpenSSL security releases do not require Node.js security releases"

### DIFF
--- a/source/_posts/2019-09-12-vulnerability-september-2019-openssl-no-updates.md
+++ b/source/_posts/2019-09-12-vulnerability-september-2019-openssl-no-updates.md
@@ -39,14 +39,14 @@ supported release lines.
 
 [보안 권고](https://www.openssl.org/news/secadv/20190910.txt)에 대한 우리의 평가는 아래와 같습니다:
 
-* ECDSA 원격 소요 시간 분석 공격(timing attack) (CVE-2019-1547)
+* ECDSA 원격 소요 시간 분석 공격(timing attack) (CVE-2019-1547):
   영향을 받지 않았습니다. Node는 ECDSA 서명에 대해 명명된 곡선만 지원합니다.
 
-* 분기(fork) 보호 (CVE-2019-1549)
+* 분기(fork) 보호 (CVE-2019-1549):
   영향을 받지 않았습니다. Node.js 항상 `fork()` 호출 후에 `exec()`을 호출하므로 
   분기된 프로세스에서 PRNG 상태를 복제하지 않습니다.
 
-* `PKCS7_dataDecode` 및 `CMS_decrypt_set1_pkey`에서의 패딩 오라클 (CVE-2019-1563)
+* `PKCS7_dataDecode` 및 `CMS_decrypt_set1_pkey`에서의 패딩 오라클 (CVE-2019-1563):
   영향을 받지 않았습니다. Node는 PCKS7 및 CMS를 지원하지 않습니다.
 
 이 평가를 바탕으로 OpenSSL 업데이트는 비보안 패치 업데이트로 취급되며, 

--- a/source/_posts/2019-09-12-vulnerability-september-2019-openssl-no-updates.md
+++ b/source/_posts/2019-09-12-vulnerability-september-2019-openssl-no-updates.md
@@ -37,7 +37,7 @@ supported release lines.
 
 ### 분석
 
-[보안 권고](https://www.openssl.org/news/secadv/20190910.txt)에 대한 우리의 평가는 아래와 같습니다:
+[보안 권고](https://www.openssl.org/news/secadv/20190910.txt)에 대한 우리의 평가는 아래와 같습니다.
 
 * ECDSA 원격 소요 시간 분석 공격(timing attack) (CVE-2019-1547):
   영향을 받지 않았습니다. Node는 ECDSA 서명에 대해 명명된 곡선만 지원합니다.

--- a/source/_posts/2019-09-12-vulnerability-september-2019-openssl-no-updates.md
+++ b/source/_posts/2019-09-12-vulnerability-september-2019-openssl-no-updates.md
@@ -1,0 +1,86 @@
+---
+category: articles
+title: OpenSSL 보안 릴리스는 Node.js 보안 릴리스를 필요로 하지 않습니다.
+author: Sam Roberts
+ref: OpenSSL security releases do not require Node.js security releases
+refurl: https://nodejs.org/en/blog/vulnerability/september-2019-openssl-no-updates
+translator: Fleta
+---
+
+<!--
+### Summary
+
+The OpenSSL Security releases of September 10th, 2019 do not affect Node.js.
+
+### Analysis
+
+Our assessment of the [security advisory](https://www.openssl.org/news/secadv/20190910.txt) is:
+
+* ECDSA remote timing attack (CVE-2019-1547)
+  Not affected. Node supports only named curves for ECDSA signing.
+
+* Fork Protection (CVE-2019-1549)
+  Not affected. Node.js always call `exec()` after `fork()` so will not
+  duplicate the PRNG state in the forked process.
+
+* Padding Oracle in `PKCS7_dataDecode` and `CMS_decrypt_set1_pkey` (CVE-2019-1563)
+  Not affected. Node does not support PCKS7 and CMS.
+
+Given this assessment, the OpenSSL updates will be treated as non-security
+patch updates, and will come out in the regularly scheduled updates to
+supported release lines.
+-->
+
+### 요약
+
+2019년 9월 10일의 OpenSSL 보안 릴리스는 Node.js에 영향을 미치지 않습니다.
+
+### 분석
+
+[보안 권고](https://www.openssl.org/news/secadv/20190910.txt)에 대한 우리의 평가는 아래와 같습니다:
+
+* ECDSA 원격 소요 시간 분석 공격(timing attack) (CVE-2019-1547)
+  영향을 받지 않았습니다. Node는 ECDSA 서명에 대해 명명된 곡선만 지원합니다.
+
+* 분기(fork) 보호 (CVE-2019-1549)
+  영향을 받지 않았습니다. Node.js 항상 `fork()` 호출 후에 `exec()`을 호출하므로 
+  분기된 프로세스에서 PRNG 상태를 복제하지 않습니다.
+
+* `PKCS7_dataDecode` 및 `CMS_decrypt_set1_pkey`에서의 패딩 오라클 (CVE-2019-1563)
+  영향을 받지 않았습니다. Node는 PCKS7 및 CMS를 지원하지 않습니다.
+
+이 평가를 바탕으로 OpenSSL 업데이트는 비보안 패치 업데이트로 취급되며, 
+지원되는 릴리스 라인에 대해 정기적으로 예약된 업데이트로 제공됩니다.
+
+<!--
+### Acknowledgements
+
+Thanks to [Shigeki Ohtsu](https://github.com/shigeki) for his rapid analysis
+of the OpenSSL security advisory.
+
+### Contact and future updates
+
+The current Node.js security policy can be found at <https://nodejs.org/en/security/>,
+including information on how to report a vulnerability in Node.js.
+
+Subscribe to the low-volume announcement-only **nodejs-sec** mailing list at
+https://groups.google.com/forum/#!forum/nodejs-sec to stay up to date on
+security vulnerabilities and security-related releases of Node.js and the
+projects maintained in the
+[nodejs GitHub organisation](https://github.com/nodejs).
+-->
+
+
+### 감사의 말
+
+OpenSSL 보안 권고를 신속하게 분석해 준 [Shigeki Ohtsu](https://github.com/shigeki)에게 감사드립니다.
+
+### 연락처 및 향후 업데이트
+
+현재 Node.js의 보안 정책과 Node.js의 취약점 보고를 위한 방법에 대한 정보는 
+<https://nodejs.org/en/security/>에서 볼 수 있습니다.
+
+Node.js의 보안 취약점과 보안과 관련된 릴리스의 최신 정보를 얻으려면
+<https://groups.google.com/forum/#!forum/nodejs-sec>에서 소수의 공지만 하는
+**nodejs-sec** 메일링 리스트를 구독해 주세요. 이 프로젝트는
+[nodejs GitHub 조직](https://github.com/nodejs/)에서 관리하고 있습니다.


### PR DESCRIPTION
close #878 