### PR TITLE
Updata CONTRIBUTING.md

### DIFF
--- a/source/CONTRIBUTING.md
+++ b/source/CONTRIBUTING.md
@@ -13,7 +13,7 @@ title: 번역 참여 가이드
 
 # 번역에 참여하는 방법
 
-* [이슈](https://github.com/nodejs/nodejs-ko/issues) 중에서 [translation 레이블이 붙은 이슈](https://github.com/nodejs/nodejs-ko/labels/translation)가 번역할 문서입니다.
+* [이슈](https://github.com/nodejs/nodejs-ko/issues) 중에서 [translation 레이블이 붙은 이슈](https://github.com/nodejs/nodejs-ko/issues?q=is%3Aopen+type%3Aissue+label%3Atranslation)가 번역할 문서입니다.
 * 댓글로 번역하겠다는 의사를 밝힙니다.
 * 이슈를 할당하면 번역의 진행을 위해서 1주일 안에 번역 작업을 합니다. 1주일이 지나면 다른 사람에게 이슈가 넘어갈 수 있습니다.
 


### PR DESCRIPTION
저의 의견으로는 translation 레이블이 붙은 **이슈** 이기 때문에 `translation 레이블이 붙은 이슈, PR`보단 `translation 레이블이 붙은 이슈 (Open만)`로 이동시키는 것이 적당해 보입니다.