### PR TITLE
Bugfix: josa() returns a string containing undefined

### DIFF
--- a/bin/translate.mjs
+++ b/bin/translate.mjs
@@ -31,14 +31,14 @@ const patterns = [
 
 function josa(str) {
   const josas = '이,가,을,를,와,과,으로,로'.split(',');
-  const getPP = (pp, hasFinal) => Math.floor(josas.indexOf(pp) / 2) * 2 + (hasFinal ? 0 : 1);
+  const getPP = (pp, hasFinal) => josas[Math.floor(josas.indexOf(pp) / 2) * 2 + (hasFinal ? 0 : 1)];
 
-  return str.replace(/(?:([a-z]+)|([가-힣])|(\d))(\([^\)]+\))?\[\[(이|가|와|과|을|를|으?로)\]\]/gi, ($0, en, ko, num, paren, pp) => {
-    if (num) return num + paren + getPP(pp, /[136780]/.test(num));  
+  return str.replace(/(?:([a-z]+)|([가-힣])|(\d))(\([^\)]*\))?\[\[(이|가|와|과|을|를|으?로)\]\]/gi, ($0, en, ko, num, paren = '', pp) => {
+    if (num) return num + paren + getPP(pp, /[136780]/.test(num));
     if (ko) return ko + paren + getPP(pp, (ko.charCodeAt(0) - 0xac00) % 28 > 0);
 
     // !Experimental - maybe need to improve
-    if (en) return en + paren + getPP(pp, /(?:m|n|ck|ng|th|[^aeiouy]e|SSL)$/.test(en));
+    if (en) return en + paren + getPP(pp, /(?:[nml]|ck|ng|th|[^aeiouy]e|SSL)$/.test(en));
 
     return $0;
   });


### PR DESCRIPTION
스캐폴딩 스크립트에 오류가 있어서 `josa()` 함수에 `undefined` 문자열이 포함되는 버그를 수정합니다.

### Test plan

```
npm run scaffold https://raw.githubusercontent.com/nodejs/nodejs.org/master/locale/en/blog/release/v15.13.0.md 2021-03-31
```

위 명령을 실행하고 생성된 파일을 열었을 때 `upgrade npm to 7.7.6`이 정상적으로 `npm의 버전을 7.7.6으로 업그레이드했습니다.`라고 번역되어야 합니다.
