### PR TITLE
2021 security april

### DIFF
--- a/source/_posts/2021-03-31-vulnerability-april-2021-security-releases.md
+++ b/source/_posts/2021-03-31-vulnerability-april-2021-security-releases.md
@@ -13,7 +13,7 @@ translator: taggon
 Updates are now available for v10,x, v12.x, v14.x and v15.x Node.js release lines for the following issues.
 -->
 
-## _(2021년 3월 6일 업데이트)_ 보안 릴리스를 사용할 수 있습니다.
+## _(2021년 4월 6일 업데이트)_ 보안 릴리스를 사용할 수 있습니다.
 
 다음 이슈에 대해 v10.x, v12.x, v14.x, v15.x 버전의 Node.js 릴리스 라인의 업데이트를 이용할 수 있습니다.
 
@@ -45,7 +45,7 @@ Impacts:
 * All versions of the 15.x, 14.x, 12.x and 10.x releases lines
 -->
 
-### OpenSSL - signature_algorithms 처리 중 NULL 포인터 참조 해제(높음) (CVE-2021-3449)
+### OpenSSL - signature_algorithms 처리 중 NULL 포인터 역참조(높음) (CVE-2021-3449)
 
 이 OpenSSL 취약점은 Node.js에서 악용될 수 있습니다.
 자세한 내용은 <https://www.openssl.org/news/secadv/20210325.txt>에서 볼 수 있습니다.

--- a/source/_posts/2021-03-31-vulnerability-april-2021-security-releases.md
+++ b/source/_posts/2021-03-31-vulnerability-april-2021-security-releases.md
@@ -8,6 +8,89 @@ translator: taggon
 ---
 
 <!--
+## _(Update 6-Apr-2021)_ Security releases available
+
+Updates are now available for v10,x, v12.x, v14.x and v15.x Node.js release lines for the following issues.
+-->
+
+## _(2021년 3월 6일 업데이트)_ 보안 릴리스를 사용할 수 있습니다.
+
+다음 이슈에 대해 v10.x, v12.x, v14.x, v15.x 버전의 Node.js 릴리스 라인의 업데이트를 이용할 수 있습니다.
+
+<!--
+### OpenSSL - CA certificate check bypass with X509_V_FLAG_X509_STRICT (High) (CVE-2021-3450)
+
+This is a vulnerability in OpenSSL which may be exploited through Node.js. You can read more about it in
+https://www.openssl.org/news/secadv/20210325.txt
+
+Impacts:
+* All versions of the 15.x, 14.x, 12.x and 10.x releases lines
+-->
+
+### OpenSSL - X509_V_FLAG_X509_STRICT를 사용할 때 CA 인증서 검사의 우회(높음) (CVE-2021-3450)
+
+이 OpenSSL 취약점은 Node.js에서 악용될 수 있습니다.
+자세한 내용은 <https://www.openssl.org/news/secadv/20210325.txt>에서 볼 수 있습니다.
+
+영향받는 버전:
+* 15.x, 14.x, 12.x, 10.x 릴리스 라인의 모든 버전
+
+<!--
+### OpenSSL - NULL pointer deref in signature_algorithms processing (High) (CVE-2021-3449)
+
+This is a vulnerability in OpenSSL which may be exploited through Node.js. You can read more about it in
+https://www.openssl.org/news/secadv/20210325.txt
+
+Impacts:
+* All versions of the 15.x, 14.x, 12.x and 10.x releases lines
+-->
+
+### OpenSSL - signature_algorithms 처리 중 NULL 포인터 참조 해제(높음) (CVE-2021-3449)
+
+이 OpenSSL 취약점은 Node.js에서 악용될 수 있습니다.
+자세한 내용은 <https://www.openssl.org/news/secadv/20210325.txt>에서 볼 수 있습니다.
+
+영향받는 버전:
+* 15.x, 14.x, 12.x, 10.x 릴리스 라인의 모든 버전
+
+<!--
+### npm upgrade - Update y18n to fix Prototype-Pollution (High) (CVE-2020-7774)
+
+This is a vulnerability in the y18n npm module which may be exploited by prototype pollution.
+You can read more about it in
+https://github.com/advisories/GHSA-c4w7-xm78-47vh
+
+Impacts:
+* All versions of the 14.x, 12.x and 10.x releases lines
+-->
+
+### npm 업그레이드 - 프로토타입 오염을 고치려고 y18n을 업데이트함(높음) (CVE-2020-7774)
+
+y18n npm 모듈의 취약점으로 프로토타입을 오염시켜서 악용될 수 있습니다.
+자세한 내용은 <https://github.com/advisories/GHSA-c4w7-xm78-47vh>에서 볼 수 있습니다.
+
+영향받는 버전:
+* 14.x, 12.x, 10.x 릴리스 라인의 모든 버전
+
+<!--
+## Downloads and release details
+
+* [Node.js v10.24.1 (LTS)](https://nodejs.org/en/blog/release/v10.24.1/)
+* [Node.js v12.22.1 (LTS)](https://nodejs.org/en/blog/release/v12.22.1/)
+* [Node.js v14.16.1 (LTS)](https://nodejs.org/en/blog/release/v14.16.1/)
+* [Node.js v15.14.0 (Current)](https://nodejs.org/en/blog/release/v15.14.0/)
+-->
+
+## 다운로드와 릴리스 세부 사항
+
+* [Node.js v10.24.1(LTS)](/nodejs-ko/articles/2021/04/06/release-v10.24.1/)
+* [Node.js v12.22.1(LTS)](/nodejs-ko/articles/2021/04/06/release-v12.22.1/)
+* [Node.js v14.16.1(LTS)](/nodejs-ko/articles/2021/04/06/release-v14.16.1/)
+* [Node.js v15.14.0(현재 버전)](/nodejs-ko/articles/2021/04/06/release-v15.14.0/)
+
+----------------
+
+<!--
 # Summary
 
 The Node.js project will release new versions of all supported release lines on or shortly after Tuesday, April 6th, 2021.

--- a/source/_posts/2021-04-06-release-v10.24.1.md
+++ b/source/_posts/2021-04-06-release-v10.24.1.md
@@ -1,0 +1,123 @@
+---
+category: articles
+title: Node v10.24.1(LTS)
+author: Myles Borins
+ref: Node v10.24.1 (LTS)
+refurl: https://nodejs.org/en/blog/release/v10.24.1
+translator: outsideris
+---
+
+<!--
+### Notable Changes
+
+Vulerabilties fixed:
+
+* **CVE-2021-3450**: OpenSSL - CA certificate check bypass with X509_V_FLAG_X509_STRICT (High)
+  * This is a vulnerability in OpenSSL which may be exploited through Node.js. You can read more about it in https://www.openssl.org/news/secadv/20210325.txt
+  * Impacts:
+    * All versions of the 15.x, 14.x, 12.x and 10.x releases lines
+* **CVE-2021-3449**: OpenSSL - NULL pointer deref in signature_algorithms processing (High)
+  * This is a vulnerability in OpenSSL which may be exploited through Node.js. You can read more about it in https://www.openssl.org/news/secadv/20210325.txt
+  * Impacts:
+    * All versions of the 15.x, 14.x, 12.x and 10.x releases lines
+* **CVE-2020-7774**: npm upgrade - Update y18n to fix Prototype-Pollution (High)
+  * This is a vulnerability in the y18n npm module which may be exploited by prototype pollution. You can read more about it in https://github.com/advisories/GHSA-c4w7-xm78-47vh
+  * Impacts:
+    * All versions of the 14.x, 12.x and 10.x releases lines
+-->
+### 주요 변경사항
+
+다음 취약점을 수정했습니다.
+
+* **CVE-2021-3450**: OpenSSL - X509_V_FLAG_X509_STRICT를 사용할 때 CA 인증서 검사의 우회(높음)
+  * 이 OpenSSL 취약점은 Node.js에서 악용될 수 있습니다. 자세한 내용은 <https://www.openssl.org/news/secadv/20210325.txt>에서 볼 수 있습니다.
+  * 영향받는 버전:
+    * 15.x, 14.x, 12.x, 10.x 릴리스 라인의 모든 버전
+* **CVE-2021-3449**: OpenSSL - signature_algorithms 처리 중 NULL 포인터 참조 해제(높음)
+  * 이 OpenSSL 취약점은 Node.js에서 악용될 수 있습니다. 자세한 내용은 <https://www.openssl.org/news/secadv/20210325.txt>에서 볼 수 있습니다.
+  * 영향받는 버전:
+    * 15.x, 14.x, 12.x, 10.x 릴리스 라인의 모든 버전
+* **CVE-2020-7774**: npm 업그레이드 - 프로토타입 오염을 고치려고 y18n을 업데이트함(높음)
+  * y18n npm 모듈의 취약점으로 프로토타입을 오염시켜서 악용될 수 있습니다. 자세한 내용은 <https://github.com/advisories/GHSA-c4w7-xm78-47vh>에서 볼 수 있습니다.
+  * 영향받는 버전:
+    * 14.x, 12.x, 10.x 릴리스 라인의 모든 버전
+
+### Commits
+
+* [[`5e526b96ce`](https://github.com/nodejs/node/commit/5e526b96ce)] - **deps**: upgrade npm to 6.14.12 (Ruy Adorno) [#37918](https://github.com/nodejs/node/pull/37918)
+* [[`781cb6df5c`](https://github.com/nodejs/node/commit/781cb6df5c)] - **deps**: update archs files for OpenSSL-1.1.1k (Tobias Nießen) [#37940](https://github.com/nodejs/node/pull/37940)
+* [[`5db0a05a90`](https://github.com/nodejs/node/commit/5db0a05a90)] - **deps**: upgrade openssl sources to 1.1.1k (Tobias Nießen) [#37940](https://github.com/nodejs/node/pull/37940)
+
+Windows 32-bit Installer: https://nodejs.org/dist/v10.24.1/node-v10.24.1-x86.msi<br>
+Windows 64-bit Installer: https://nodejs.org/dist/v10.24.1/node-v10.24.1-x64.msi<br>
+Windows 32-bit Binary: https://nodejs.org/dist/v10.24.1/win-x86/node.exe<br>
+Windows 64-bit Binary: https://nodejs.org/dist/v10.24.1/win-x64/node.exe<br>
+macOS 64-bit Installer: https://nodejs.org/dist/v10.24.1/node-v10.24.1.pkg<br>
+macOS 64-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-darwin-x64.tar.gz<br>
+Linux 64-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-linux-x64.tar.xz<br>
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-linux-ppc64le.tar.xz<br>
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-linux-s390x.tar.xz<br>
+AIX 64-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-aix-ppc64.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-sunos-x64.tar.xz<br>
+ARMv6 32-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-linux-armv6l.tar.xz<br>
+ARMv7 32-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-linux-armv7l.tar.xz<br>
+ARMv8 64-bit Binary: https://nodejs.org/dist/v10.24.1/node-v10.24.1-linux-arm64.tar.xz<br>
+Source Code: https://nodejs.org/dist/v10.24.1/node-v10.24.1.tar.gz<br>
+Other release files: https://nodejs.org/dist/v10.24.1/<br>
+Documentation: https://nodejs.org/docs/v10.24.1/api/
+
+### SHASUMS
+
+```
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA256
+
+fc9ba4f3ba0be4a4495dd4fc7aa1e608f74a1440264518da760b246417077c3f  node-v10.24.1-aix-ppc64.tar.gz
+8088968a896e17c21b98187f8083291df9c88d0baa100a6cb9553e53c4fb17f8  node-v10.24.1-darwin-x64.tar.gz
+8edae5060c7513de8e764cdbb61daea5ae652b7a3a457d412a7e08c04e5202da  node-v10.24.1-darwin-x64.tar.xz
+d38ae7bed508836129fac4163f3db5a0df5ea1dd26bf4a66f88146cbe770b788  node-v10.24.1-headers.tar.gz
+1149f00ce0cec044e60deb723d1c1e682083c9ec6edc05cd1326f2031412a68e  node-v10.24.1-headers.tar.xz
+0ae4931d0ea779ecb237c1fc9f4a27271b0054b1efabc783863478913fe6caa6  node-v10.24.1-linux-arm64.tar.gz
+b11ce837867e50d1b2bf09da6a85336bedfa257bf92f34712aeb94360c0bcd6e  node-v10.24.1-linux-arm64.tar.xz
+cf19f1965bca6b4ade9396e31f9490448ded2402713fdfe2d43410da037d9b5c  node-v10.24.1-linux-armv6l.tar.gz
+01c992bb0ec60552dbe3c96b5333bc0bb0c0eda9077af532c8869f82d49a63c8  node-v10.24.1-linux-armv6l.tar.xz
+5b156bbd04adfaad2184b4d1e8324b21b546b40fb46e7105fa39f5ad2f34ddf3  node-v10.24.1-linux-armv7l.tar.gz
+0d2c8991598c15f1efe31d6986f50d46016f74876194c257d7d0108c2c9de2da  node-v10.24.1-linux-armv7l.tar.xz
+8dc58449fe7b0368c417bb6ead8197bf1549e4502b42e62f3e51dce11b37fcd0  node-v10.24.1-linux-ppc64le.tar.gz
+e99c2e7115361ab02e320053d2ee3619445349fa02b5082a12560014c0decf6a  node-v10.24.1-linux-ppc64le.tar.xz
+7ec1bd172b58bc9d7782d2d4428a298167b7297b8f1812a21eb6e4285bbe9ef2  node-v10.24.1-linux-s390x.tar.gz
+aff7f704dc27da4bb6c0b8df83d0eeac2cf4c97825be0994fbdc14319da7a29c  node-v10.24.1-linux-s390x.tar.xz
+7a70083a73719a3c7846533923d5c4e955405c2b4ba1c1abd95ed21ae8b52775  node-v10.24.1-linux-x64.tar.gz
+a3b9b97c23bcdc64334be6b02422e9014f040d59dcf604563ffda48003419356  node-v10.24.1-linux-x64.tar.xz
+49f4e193b049a401a2f1fd98e3a7471d038418d81a37df2b64e88543f43b08a9  node-v10.24.1.pkg
+20f0a296f544b5f5cb4122cb1c2aa080d83f0212c279147df4373d988b466657  node-v10.24.1-sunos-x64.tar.gz
+3daf48c796f3edfc67cd25516fe7ff3a2a33c4da449f5c5c29dce98ba5e51834  node-v10.24.1-sunos-x64.tar.xz
+95c7cfc4b5ad0b5a62bd553b30840db66f21217fbeb769ab27dac8019a4ebe5d  node-v10.24.1.tar.gz
+d72fc2c244603b4668da94081dc4d6067d467fdfa026e06a274012f16600480c  node-v10.24.1.tar.xz
+af98dda863785269a2db1bea8c3931e34d53f495f21d27fe8472154ee9a67cc4  node-v10.24.1-win-x64.7z
+ae0af1b5e0c131dd0df1b3e4713c36e5d7f652ab6ca273ce46d39d4df8522bb0  node-v10.24.1-win-x64.zip
+746db6e34b0d46695789fed30962f570fb5ee699590627459148d6e639eed55e  node-v10.24.1-win-x86.7z
+e39380da3a5f859f98b5a07e153e062c7fca852077693f99ad528705f5c0deb5  node-v10.24.1-win-x86.zip
+dab263436eeda26c9c4809ba4d93e607dcffb3735b9a1866c77afb242a832dbd  node-v10.24.1-x64.msi
+dbddbb2e29da2e4c060510d3a466895555f458b5eb090756c9aad52858a9d61b  node-v10.24.1-x86.msi
+6664cc00232d95f73e050f25b1dd1000b44f63e35f051734c9bee478cd3574c7  win-x64/node.exe
+7688ed23318d253aa98ee198f94983e4b563fab188e6fd9dd32955e77111096a  win-x64/node.lib
+3bff6336aa859467f7710aad3286706306d165041af5ea2daaec3e1fa0fe86c7  win-x64/node_pdb.7z
+36d49e29a33ee0fbb229fb2abee8bf093b3ea7fe70e7b31215c38f64900d435e  win-x64/node_pdb.zip
+6f1cf2bc2b17d51478f9f17db6ae51e1cc4126bc7f5a967a95c5ab5c8d9a26c0  win-x86/node.exe
+de1f3445597cbbee2e5eac435651f5dcab049a2d8bd3636877ab5803a87e269e  win-x86/node.lib
+4d3f9bd319fe33f8a5991712264d3feb0247caa1bc9da2f47f6cb83386baf1bd  win-x86/node_pdb.7z
+9bd12506802cc20fbaa398c5dcc6ba4a72bffca9cc7cd526f7c69582eb526b53  win-x86/node_pdb.zip
+-----BEGIN PGP SIGNATURE-----
+
+iQEzBAEBCAAdFiEEDv/hvO/ZyE49CYFSkzsB9AtcqUYFAmBsvQIACgkQkzsB9Atc
+qUZOjwf/ZZUDOIWnozg+4OQPZZNL66GppgYikwh1rzPoAki9wIsaDWJKO0+zkZkX
+H489vQEfnO2tli247xDJtFXoK/Vjbgr/Jh5bIYoMWjqmdEs/oicUsarOlswog4ba
+E2xPxlIqShbKweexISuoZVupzQ6hhw/bM3C5OPjy48WjockiqUJVCahLahNKuz9r
+ssFqeH1j283xbN5WZ93OGLuFwpgJ+yFRVjuAJI2+G/lNG/XFymVsMQKbJzOCTT5O
+sGJ60uzG94o4bgvtdWYZWo0psHJq1Vce8v3EK9SnOf4/zDovqAs/9loshDJsI+5g
+NIzEPAM3KwzyexE7LoOZKdI2POGJjg==
+=sJuP
+-----END PGP SIGNATURE-----
+
+```

--- a/source/_posts/2021-04-06-release-v10.24.1.md
+++ b/source/_posts/2021-04-06-release-v10.24.1.md
@@ -33,7 +33,7 @@ Vulerabilties fixed:
   * 이 OpenSSL 취약점은 Node.js에서 악용될 수 있습니다. 자세한 내용은 <https://www.openssl.org/news/secadv/20210325.txt>에서 볼 수 있습니다.
   * 영향받는 버전:
     * 15.x, 14.x, 12.x, 10.x 릴리스 라인의 모든 버전
-* **CVE-2021-3449**: OpenSSL - signature_algorithms 처리 중 NULL 포인터 참조 해제(높음)
+* **CVE-2021-3449**: OpenSSL - signature_algorithms 처리 중 NULL 포인터 역참조(높음)
   * 이 OpenSSL 취약점은 Node.js에서 악용될 수 있습니다. 자세한 내용은 <https://www.openssl.org/news/secadv/20210325.txt>에서 볼 수 있습니다.
   * 영향받는 버전:
     * 15.x, 14.x, 12.x, 10.x 릴리스 라인의 모든 버전

--- a/source/_posts/2021-04-06-release-v12.22.1.md
+++ b/source/_posts/2021-04-06-release-v12.22.1.md
@@ -33,7 +33,7 @@ Vulnerabilities fixed:
   * 이 OpenSSL 취약점은 Node.js에서 악용될 수 있습니다. 자세한 내용은 <https://www.openssl.org/news/secadv/20210325.txt>에서 볼 수 있습니다.
   * 영향받는 버전:
     * 15.x, 14.x, 12.x, 10.x 릴리스 라인의 모든 버전
-* **CVE-2021-3449**: OpenSSL - signature_algorithms 처리 중 NULL 포인터 참조 해제(높음)
+* **CVE-2021-3449**: OpenSSL - signature_algorithms 처리 중 NULL 포인터 역참조(높음)
   * 이 OpenSSL 취약점은 Node.js에서 악용될 수 있습니다. 자세한 내용은 <https://www.openssl.org/news/secadv/20210325.txt>에서 볼 수 있습니다.
   * 영향받는 버전:
     * 15.x, 14.x, 12.x, 10.x 릴리스 라인의 모든 버전

--- a/source/_posts/2021-04-06-release-v12.22.1.md
+++ b/source/_posts/2021-04-06-release-v12.22.1.md
@@ -1,0 +1,120 @@
+---
+category: articles
+title: Node v12.22.1(LTS)
+author: Myles Borins
+ref: Node v12.22.1 (LTS)
+refurl: https://nodejs.org/en/blog/release/v12.22.1
+translator: outsideris
+---
+
+<!--
+### Notable Changes
+
+Vulnerabilities fixed:
+
+* **CVE-2021-3450**: OpenSSL - CA certificate check bypass with X509_V_FLAG_X509_STRICT (High)
+  * This is a vulnerability in OpenSSL which may be exploited through Node.js. You can read more about it in https://www.openssl.org/news/secadv/20210325.txt
+  * Impacts:
+    * All versions of the 15.x, 14.x, 12.x and 10.x releases lines
+* **CVE-2021-3449**: OpenSSL - NULL pointer deref in signature_algorithms processing (High)
+  * This is a vulnerability in OpenSSL which may be exploited through Node.js. You can read more about it in https://www.openssl.org/news/secadv/20210325.txt
+  * Impacts:
+    * All versions of the 15.x, 14.x, 12.x and 10.x releases lines
+* **CVE-2020-7774**: npm upgrade - Update y18n to fix Prototype-Pollution (High)
+  * This is a vulnerability in the y18n npm module which may be exploited by prototype pollution. You can read more about it in https://github.com/advisories/GHSA-c4w7-xm78-47vh
+  * Impacts:
+    * All versions of the 14.x, 12.x and 10.x releases lines
+-->
+### 주요 변경사항
+
+다음 취약점을 수정했습니다.
+
+* **CVE-2021-3450**: OpenSSL - X509_V_FLAG_X509_STRICT를 사용할 때 CA 인증서 검사의 우회(높음)
+  * 이 OpenSSL 취약점은 Node.js에서 악용될 수 있습니다. 자세한 내용은 <https://www.openssl.org/news/secadv/20210325.txt>에서 볼 수 있습니다.
+  * 영향받는 버전:
+    * 15.x, 14.x, 12.x, 10.x 릴리스 라인의 모든 버전
+* **CVE-2021-3449**: OpenSSL - signature_algorithms 처리 중 NULL 포인터 참조 해제(높음)
+  * 이 OpenSSL 취약점은 Node.js에서 악용될 수 있습니다. 자세한 내용은 <https://www.openssl.org/news/secadv/20210325.txt>에서 볼 수 있습니다.
+  * 영향받는 버전:
+    * 15.x, 14.x, 12.x, 10.x 릴리스 라인의 모든 버전
+* **CVE-2020-7774**: npm 업그레이드 - 프로토타입 오염을 고치려고 y18n을 업데이트함(높음)
+  * y18n npm 모듈의 취약점으로 프로토타입을 오염시켜서 악용될 수 있습니다. 자세한 내용은 <https://github.com/advisories/GHSA-c4w7-xm78-47vh>에서 볼 수 있습니다.
+  * 영향받는 버전:
+    * 14.x, 12.x, 10.x 릴리스 라인의 모든 버전
+
+### Commits
+
+* [[`c947f1a0e1`](https://github.com/nodejs/node/commit/c947f1a0e1)] - **deps**: upgrade npm to 6.14.12 (Ruy Adorno) [#37918](https://github.com/nodejs/node/pull/37918)
+* [[`51a753c06f`](https://github.com/nodejs/node/commit/51a753c06f)] - **deps**: update archs files for OpenSSL-1.1.1k (Tobias Nießen) [#37939](https://github.com/nodejs/node/pull/37939)
+* [[`c85a519b48`](https://github.com/nodejs/node/commit/c85a519b48)] - **deps**: upgrade openssl sources to 1.1.1k (Tobias Nießen) [#37939](https://github.com/nodejs/node/pull/37939)
+
+Windows 32-bit Installer: https://nodejs.org/dist/v12.22.1/node-v12.22.1-x86.msi<br>
+Windows 64-bit Installer: https://nodejs.org/dist/v12.22.1/node-v12.22.1-x64.msi<br>
+Windows 32-bit Binary: https://nodejs.org/dist/v12.22.1/win-x86/node.exe<br>
+Windows 64-bit Binary: https://nodejs.org/dist/v12.22.1/win-x64/node.exe<br>
+macOS 64-bit Installer: https://nodejs.org/dist/v12.22.1/node-v12.22.1.pkg<br>
+macOS 64-bit Binary: https://nodejs.org/dist/v12.22.1/node-v12.22.1-darwin-x64.tar.gz<br>
+Linux 64-bit Binary: https://nodejs.org/dist/v12.22.1/node-v12.22.1-linux-x64.tar.xz<br>
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v12.22.1/node-v12.22.1-linux-ppc64le.tar.xz<br>
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v12.22.1/node-v12.22.1-linux-s390x.tar.xz<br>
+AIX 64-bit Binary: https://nodejs.org/dist/v12.22.1/node-v12.22.1-aix-ppc64.tar.gz<br>
+SmartOS 64-bit Binary: https://nodejs.org/dist/v12.22.1/node-v12.22.1-sunos-x64.tar.xz<br>
+ARMv7 32-bit Binary: https://nodejs.org/dist/v12.22.1/node-v12.22.1-linux-armv7l.tar.xz<br>
+ARMv8 64-bit Binary: https://nodejs.org/dist/v12.22.1/node-v12.22.1-linux-arm64.tar.xz<br>
+Source Code: https://nodejs.org/dist/v12.22.1/node-v12.22.1.tar.gz<br>
+Other release files: https://nodejs.org/dist/v12.22.1/<br>
+Documentation: https://nodejs.org/docs/v12.22.1/api/
+
+### SHASUMS
+
+```
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA256
+
+696f48b080915eb08e2ae24349a32ce56520483ac982fb51cce4876b82ab1bf5  node-v12.22.1-aix-ppc64.tar.gz
+9cbade90e2e89feba674b1841573e6f0329e6ba4bd3ecc1f5e0c5c6785db6dc0  node-v12.22.1-darwin-x64.tar.gz
+de5e317580732530961d83b0fb9b2c370d222bd0c5a1b331900e9ddc0fdfe086  node-v12.22.1-darwin-x64.tar.xz
+9355a0af101ccba1ae90c3f1f3d71ed821934c875462a76f8b65a6f7ee7293fd  node-v12.22.1-headers.tar.gz
+f6db5ceaf820a2899712baeccb2a09950ab3bf8d4c0d893d672aeba54c1f4162  node-v12.22.1-headers.tar.xz
+917c582b7f7ae5ff8b2d97e05d00598011f9fbfcc4f76952da3ed477405c9c1a  node-v12.22.1-linux-arm64.tar.gz
+65145e6c2aa047ee5f83aadf9546116a6da70c21a649ed5f24dce412d2c202dc  node-v12.22.1-linux-arm64.tar.xz
+1bc056e1fef1c83059235d927edea2c1a2eee91ce654f45369a2af95c041e198  node-v12.22.1-linux-armv7l.tar.gz
+4ae8e0d3dee7273ed8e07f80b74b05fc16a5562a42c13c9971d595b7ece4de71  node-v12.22.1-linux-armv7l.tar.xz
+38d42033a10b535eb0285ccf7b7f2e6511bcb6f383c4620a53071d3b8f929d03  node-v12.22.1-linux-ppc64le.tar.gz
+f85a1a9f5476d35aec37d8052330d3d3d8e216276881181b06505758119c2c3b  node-v12.22.1-linux-ppc64le.tar.xz
+8fbf03069c758ff544110d04713d10136ce1b48a4bf2378ec17e1035a0b6a5f1  node-v12.22.1-linux-s390x.tar.gz
+c24dedddedf1a6aaff4ef40c2196f8f3c2cf99702c0be2ce6f77f740919f7dbf  node-v12.22.1-linux-s390x.tar.xz
+d315c5dea4d96658164cdb257bd8dbb5e44bdd2a7c1d747841f06515f23a0042  node-v12.22.1-linux-x64.tar.gz
+8b537282c222ae4a40e019a52f769ca27b6640699bdde1510375e8d72da7d041  node-v12.22.1-linux-x64.tar.xz
+5b1b527e3087a2de2529f5079a0b53fcc8a4909830d43156feae6b6d31c7680a  node-v12.22.1.pkg
+00ac4e9b87eb7c50cfd7a3811e7a160b2d078c6dd063fd57c8d8844310fdbc38  node-v12.22.1-sunos-x64.tar.gz
+6ae1f81151092296ec4b26b18c57aefc57b53d8f9fdd94fe60efd8fa68379f2a  node-v12.22.1-sunos-x64.tar.xz
+6023f1f8f03f9780c75e6eca9d372b8411a83757c0389c51baee1c7242afd702  node-v12.22.1.tar.gz
+dd650df7773a6ed3e390320ba51ef33cba6499f0e9397709ea3d1debdcbcb989  node-v12.22.1.tar.xz
+465100b7be0835048810978b957667ad193faa68728cfb0e02bffcaafe575795  node-v12.22.1-win-x64.7z
+0cf3545c1ff9717bf3196eed6a423d878709ed4560125fdc29b42bd80ee661c3  node-v12.22.1-win-x64.zip
+1f3dcf6707e7afeeae767f8146789540518ddb8ad974c56fda6fd2486170e5b9  node-v12.22.1-win-x86.7z
+832bd047d3709e4229d1cc95d04391aceb991a5c957b8efd395e01f51832a774  node-v12.22.1-win-x86.zip
+02f53b3530a0310b1076db801770803527c63f724b56c22d6a0625c12a03c982  node-v12.22.1-x64.msi
+8192400d6fc7083b8bf049613c046923e8c24dd913a18189be9fe77be4c1c8c4  node-v12.22.1-x86.msi
+d872b1b906cfc5ecffa69fb0a673ae60d0df772cb3e6646e32273afd4ffe923c  win-x64/node.exe
+28e5c24831deedbf4fb8a9560f2c4f95205479c589f54a9a53ec346f6a5cf8bf  win-x64/node.lib
+17cb8ad34c2584b22f9e8f9bf57e4c22fc985154b97af3ef24b7d5d34300642f  win-x64/node_pdb.7z
+fedcb273459441a94df6575b9df92dc2df360d001cc226a00f85cc9ad8c97874  win-x64/node_pdb.zip
+6f02a21ff1218ac70a0d6c14c217e9d1c8a8a9130a1b087f959ba32deb35be70  win-x86/node.exe
+8bbcf3b9305b83f54bd80f8ec19d4e237841bde5bfaeb2aec708c36daa6435f6  win-x86/node.lib
+a22c1bdd4caebc7e498ea56c74fba08698f508f2e1953ab8c6086488f61af1b2  win-x86/node_pdb.7z
+0b91ea5635cf1ec14b587e715578905dabdaa6aec3d6ed522a6b44bbe64c3a95  win-x86/node_pdb.zip
+-----BEGIN PGP SIGNATURE-----
+
+iQEzBAEBCAAdFiEEDv/hvO/ZyE49CYFSkzsB9AtcqUYFAmBsvTAACgkQkzsB9Atc
+qUZvLAf+JAApgWIpHzTzH0zgYyIsd4Pb7xX4hghwuEOAciHGFBaHaLOklXjEYpX+
+Xq7GsTtmtrB9cpAZGvK5bsF18Kq0NMOI6a2z9nYriO/4MmxJboP6/y48t978/MJi
+ZooGZ6jLO1hRKsg6vljrXrMQoCUD4ejNUuDDto50FZHWOBMqdczDBrF9vx6fMlsy
+IJALPDzGjxzNMFLitS2gzgv4VI8K1xoDr+bpxVSUQ1IVGIFtxNt3dIyGDGmM6A6M
+U3uHPMDlk2u0Q16sD+Iydo1cmDvMnqHrTTXeSSUKjnWv/apg+h8CMgjnyrLZGn7p
+efnxlKizKdfEpMiA2FOW3BKbYSd59Q==
+=kAxw
+-----END PGP SIGNATURE-----
+
+```

--- a/source/_posts/2021-04-06-release-v14.16.1.md
+++ b/source/_posts/2021-04-06-release-v14.16.1.md
@@ -1,0 +1,117 @@
+---
+category: articles
+title: Node v14.16.1(LTS)
+author: Myles Borins
+ref: Node v14.16.1 (LTS)
+refurl: https://nodejs.org/en/blog/release/v14.16.1
+translator: outsideris
+---
+
+<!--
+### Notable Changes
+
+Vulnerabilities fixed:
+
+* **CVE-2021-3450**: OpenSSL - CA certificate check bypass with X509_V_FLAG_X509_STRICT (High)
+  * This is a vulnerability in OpenSSL which may be exploited through Node.js. You can read more about it in https://www.openssl.org/news/secadv/20210325.txt
+  * Impacts:
+    * All versions of the 15.x, 14.x, 12.x and 10.x releases lines
+* **CVE-2021-3449**: OpenSSL - NULL pointer deref in signature_algorithms processing (High)
+  * This is a vulnerability in OpenSSL which may be exploited through Node.js. You can read more about it in https://www.openssl.org/news/secadv/20210325.txt
+  * Impacts:
+    * All versions of the 15.x, 14.x, 12.x and 10.x releases lines
+* **CVE-2020-7774**: npm upgrade - Update y18n to fix Prototype-Pollution (High)
+  * This is a vulnerability in the y18n npm module which may be exploited by prototype pollution. You can read more about it in https://github.com/advisories/GHSA-c4w7-xm78-47vh
+  * Impacts:
+    * All versions of the 14.x, 12.x and 10.x releases lines
+-->
+### 주요 변경사항
+
+다음 취약점을 수정했습니다.
+
+* **CVE-2021-3450**: OpenSSL - X509_V_FLAG_X509_STRICT를 사용할 때 CA 인증서 검사의 우회(높음)
+  * 이 OpenSSL 취약점은 Node.js에서 악용될 수 있습니다. 자세한 내용은 <https://www.openssl.org/news/secadv/20210325.txt>에서 볼 수 있습니다.
+  * 영향받는 버전:
+    * 15.x, 14.x, 12.x, 10.x 릴리스 라인의 모든 버전
+* **CVE-2021-3449**: OpenSSL - signature_algorithms 처리 중 NULL 포인터 참조 해제(높음)
+  * 이 OpenSSL 취약점은 Node.js에서 악용될 수 있습니다. 자세한 내용은 <https://www.openssl.org/news/secadv/20210325.txt>에서 볼 수 있습니다.
+  * 영향받는 버전:
+    * 15.x, 14.x, 12.x, 10.x 릴리스 라인의 모든 버전
+* **CVE-2020-7774**: npm 업그레이드 - 프로토타입 오염을 고치려고 y18n을 업데이트함(높음)
+  * y18n npm 모듈의 취약점으로 프로토타입을 오염시켜서 악용될 수 있습니다. 자세한 내용은 <https://github.com/advisories/GHSA-c4w7-xm78-47vh>에서 볼 수 있습니다.
+  * 영향받는 버전:
+    * 14.x, 12.x, 10.x 릴리스 라인의 모든 버전
+
+### Commits
+
+* [[`467be7a950`](https://github.com/nodejs/node/commit/467be7a950)] - **deps**: upgrade npm to 6.14.12 (Ruy Adorno) [#37918](https://github.com/nodejs/node/pull/37918)
+* [[`6bc8f58182`](https://github.com/nodejs/node/commit/6bc8f58182)] - **deps**: update archs files for OpenSSL-1.1.1k (Tobias Nießen) [#37938](https://github.com/nodejs/node/pull/37938)
+* [[`403a014ef6`](https://github.com/nodejs/node/commit/403a014ef6)] - **deps**: upgrade openssl sources to 1.1.1k (Tobias Nießen) [#37938](https://github.com/nodejs/node/pull/37938)
+
+Windows 32-bit Installer: https://nodejs.org/dist/v14.16.1/node-v14.16.1-x86.msi<br>
+Windows 64-bit Installer: https://nodejs.org/dist/v14.16.1/node-v14.16.1-x64.msi<br>
+Windows 32-bit Binary: https://nodejs.org/dist/v14.16.1/win-x86/node.exe<br>
+Windows 64-bit Binary: https://nodejs.org/dist/v14.16.1/win-x64/node.exe<br>
+macOS 64-bit Installer: https://nodejs.org/dist/v14.16.1/node-v14.16.1.pkg<br>
+macOS 64-bit Binary: https://nodejs.org/dist/v14.16.1/node-v14.16.1-darwin-x64.tar.gz<br>
+Linux 64-bit Binary: https://nodejs.org/dist/v14.16.1/node-v14.16.1-linux-x64.tar.xz<br>
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v14.16.1/node-v14.16.1-linux-ppc64le.tar.xz<br>
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v14.16.1/node-v14.16.1-linux-s390x.tar.xz<br>
+AIX 64-bit Binary: https://nodejs.org/dist/v14.16.1/node-v14.16.1-aix-ppc64.tar.gz<br>
+ARMv7 32-bit Binary: https://nodejs.org/dist/v14.16.1/node-v14.16.1-linux-armv7l.tar.xz<br>
+ARMv8 64-bit Binary: https://nodejs.org/dist/v14.16.1/node-v14.16.1-linux-arm64.tar.xz<br>
+Source Code: https://nodejs.org/dist/v14.16.1/node-v14.16.1.tar.gz<br>
+Other release files: https://nodejs.org/dist/v14.16.1/<br>
+Documentation: https://nodejs.org/docs/v14.16.1/api/
+
+### SHASUMS
+
+```
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA256
+
+79d7201c1cc0765248f6b96d6377aa1f02c27c12814275a93cb3eaa2a25eec2c  node-v14.16.1-aix-ppc64.tar.gz
+b762b72fc149629b7e394ea9b75a093cad709a9f2f71480942945d8da0fc1218  node-v14.16.1-darwin-x64.tar.gz
+72d890963c4497272eef3df1a1d46a8c64c4c356ed3f8c0ede5cb1ba8d8dd0f7  node-v14.16.1-darwin-x64.tar.xz
+8aff317d131fd4959614953ccb819639c68c284d7c8203be23cb4659e3b5f52f  node-v14.16.1-headers.tar.gz
+c5ec269e9a4d05b89013f4b7d1585d249d61809ea6f65591845dd426f00c15f0  node-v14.16.1-headers.tar.xz
+58cb307666ed4aa751757577a563b8a1e5d4ee73a9fac2b495e5c463682a07d1  node-v14.16.1-linux-arm64.tar.gz
+b4d474e79f7d33b3b4430fad25c3f836b82ce2d5bb30d4a2c9fa20df027e40da  node-v14.16.1-linux-arm64.tar.xz
+54efe997dbeff971b1e39c8eb910566ecb68cfd6140a6b5c738265d4b5842d24  node-v14.16.1-linux-armv7l.tar.gz
+1bc47a47f4415c64b6adb478857b7a1f6bc586ed61e946f03c25ea648867665e  node-v14.16.1-linux-armv7l.tar.xz
+de6ccb9bf08520939cc2ae0507634015981604b5eb6912d031d4b7fe146f0de4  node-v14.16.1-linux-ppc64le.tar.gz
+349e415bb7a95c0183ba474654c42f41ac0ceb02acca1609ff111f91e6d32189  node-v14.16.1-linux-ppc64le.tar.xz
+4a78bb87682f55106d68e38f996adc0f5d7089ce62b8222150828582aabdf3eb  node-v14.16.1-linux-s390x.tar.gz
+af9982fef32e4a3e4a5d66741dcf30ac9c27613bd73582fa1dae1fb25003047a  node-v14.16.1-linux-s390x.tar.xz
+068400cb9f53d195444b9260fd106f7be83af62bb187932656b68166a2f87f44  node-v14.16.1-linux-x64.tar.gz
+85a89d2f68855282c87851c882d4c4bbea4cd7f888f603722f0240a6e53d89df  node-v14.16.1-linux-x64.tar.xz
+3dc7987ec419767afd07dfebb2f0dcd5ae27419939d49174e5b9efc1e3b4d45b  node-v14.16.1.pkg
+5f5080427abddde7f22fd2ba77cd2b8a1f86253277a1eec54bc98a202728ce80  node-v14.16.1.tar.gz
+e44adbbed6756c2c1a01258383e9f00df30c147b36e438f6369b5ef1069abac3  node-v14.16.1.tar.xz
+3797bbe3c9ff6a0052eb550afcbf2af1ba7374743e54ce89039bbbcd3e988944  node-v14.16.1-win-x64.7z
+e469db37b4df74627842d809566c651042d86f0e6006688f0f5fe3532c6dfa41  node-v14.16.1-win-x64.zip
+005a8c367608d96eb13a79d78cf28df161ee8aa63766e6d130c7ae3977dd241a  node-v14.16.1-win-x86.7z
+cfb3535a172fb792a63814deffde405466902359bedfbd884188f6fc56f97d64  node-v14.16.1-win-x86.zip
+c90d32952154eb1ef3ebef5a5d6ec4b752e5d0f1520f9d2ebdef6685a2d3a4ec  node-v14.16.1-x64.msi
+d9cad1fbbe479f39949b36ff10df9c9afe3498621d50426e7dc8eff1c6740636  node-v14.16.1-x86.msi
+a2d5d5d4c68faf9ca14429c30d9b61cdf23e0a6f76dc3269aa2af34b3e72a1bd  win-x64/node.exe
+c8a28cc134d7455d168de698b0cfc930870c9e3fd345bbd1f496d31b530fd41e  win-x64/node.lib
+2a7a090edbcc97e0d1c40606b4c4549424d07971c7c5fcd5cb874ce472a1fe99  win-x64/node_pdb.7z
+9de7516f6c91daa1d0466b23c592c0a4ce4f1e59f796b024b7a14798bd1afb2e  win-x64/node_pdb.zip
+56d7208ca2d42a16292057d0452a958cb503beab6fc00922c85ecb9169c10f95  win-x86/node.exe
+d0ab95fdb156a779340288cc9fe342d9976922edbc7d60992f9d7ebc572c52a3  win-x86/node.lib
+bc3dbf099e1e2b4e041efab4ad0fe9584fcbb17ab0c6ea8919faafed626ba4f3  win-x86/node_pdb.7z
+e89aee0d4cea68186b9c23a503a17fcbcdfd37e0e27e9ec08cd2bc9ebb68c9a2  win-x86/node_pdb.zip
+-----BEGIN PGP SIGNATURE-----
+
+iQEzBAEBCAAdFiEEDv/hvO/ZyE49CYFSkzsB9AtcqUYFAmBsvX8ACgkQkzsB9Atc
+qUau0gf+LXe1QZmLbMS1LSwgd6db9yiGdaQfgAdvd952ZLXAHUOKFfbwlR8GchLr
+rdZe0w/6BIpC9JfCZihQ/uRBkQnwHNx135FWQpaDHlEpAfJ3r9qlGORXtOskLdPI
+Q2mYJgdgxSqMC2pxwJYZq36aPd+pu8cDBgJPKSiE7pnJltUrHj5M0axXTRRk1izP
+f2BCK4YMQlr6PZgBHbpBBHaU29HlKKP89OCPpr2KLyNZ2OVOpEQltn1TIfJQc4/C
+448jhTXAnBlFrHmbV2xVamD0K8GHgZcvLTySlf58GN9FHUuiPGcbI5dfi1nNleoh
+mpPtZ4kD6y9W3kRh1nU/sV9ijGeYDQ==
+=g8kB
+-----END PGP SIGNATURE-----
+
+```

--- a/source/_posts/2021-04-06-release-v14.16.1.md
+++ b/source/_posts/2021-04-06-release-v14.16.1.md
@@ -33,7 +33,7 @@ Vulnerabilities fixed:
   * 이 OpenSSL 취약점은 Node.js에서 악용될 수 있습니다. 자세한 내용은 <https://www.openssl.org/news/secadv/20210325.txt>에서 볼 수 있습니다.
   * 영향받는 버전:
     * 15.x, 14.x, 12.x, 10.x 릴리스 라인의 모든 버전
-* **CVE-2021-3449**: OpenSSL - signature_algorithms 처리 중 NULL 포인터 참조 해제(높음)
+* **CVE-2021-3449**: OpenSSL - signature_algorithms 처리 중 NULL 포인터 역참조(높음)
   * 이 OpenSSL 취약점은 Node.js에서 악용될 수 있습니다. 자세한 내용은 <https://www.openssl.org/news/secadv/20210325.txt>에서 볼 수 있습니다.
   * 영향받는 버전:
     * 15.x, 14.x, 12.x, 10.x 릴리스 라인의 모든 버전

--- a/source/_posts/2021-04-06-release-v15.14.0.md
+++ b/source/_posts/2021-04-06-release-v15.14.0.md
@@ -43,7 +43,7 @@ Other Notable Changes:
   * 이 OpenSSL 취약점은 Node.js에서 악용될 수 있습니다. 자세한 내용은 <https://www.openssl.org/news/secadv/20210325.txt>에서 볼 수 있습니다.
   * 영향받는 버전:
     * 15.x, 14.x, 12.x, 10.x 릴리스 라인의 모든 버전
-* **CVE-2021-3449**: OpenSSL - signature_algorithms 처리 중 NULL 포인터 참조 해제(높음)
+* **CVE-2021-3449**: OpenSSL - signature_algorithms 처리 중 NULL 포인터 역참조(높음)
   * 이 OpenSSL 취약점은 Node.js에서 악용될 수 있습니다. 자세한 내용은 <https://www.openssl.org/news/secadv/20210325.txt>에서 볼 수 있습니다.
   * 영향받는 버전:
     * 15.x, 14.x, 12.x, 10.x 릴리스 라인의 모든 버전

--- a/source/_posts/2021-04-06-release-v15.14.0.md
+++ b/source/_posts/2021-04-06-release-v15.14.0.md
@@ -1,0 +1,173 @@
+---
+category: articles
+title: Node v15.14.0(현재 버전)
+author: Myles Borins
+ref: Node v15.14.0 (Current)
+refurl: https://nodejs.org/en/blog/release/v15.14.0
+translator: outsideris
+---
+
+<!--
+### Notable Changes
+
+Vulnerabilties Fixed:
+
+* **CVE-2021-3450**: OpenSSL - CA certificate check bypass with X509_V_FLAG_X509_STRICT (High)
+  * This is a vulnerability in OpenSSL which may be exploited through Node.js. You can read more about it in https://www.openssl.org/news/secadv/20210325.txt
+  * Impacts:
+    * All versions of the 15.x, 14.x, 12.x and 10.x releases lines
+* **CVE-2021-3449**: OpenSSL - NULL pointer deref in signature_algorithms processing (High)
+  * This is a vulnerability in OpenSSL which may be exploited through Node.js. You can read more about it in https://www.openssl.org/news/secadv/20210325.txt
+  * Impacts:
+    * All versions of the 15.x, 14.x, 12.x and 10.x releases lines
+* **CVE-2020-7774**: npm upgrade - Update y18n to fix Prototype-Pollution (High)
+  * This is a vulnerability in the y18n npm module which may be exploited by prototype pollution. You can read more about it in https://github.com/advisories/GHSA-c4w7-xm78-47vh
+  * Impacts:
+    * All versions of the 14.x, 12.x and 10.x releases lines
+
+Other Notable Changes:
+
+* [[`b6f4901221`](https://github.com/nodejs/node/commit/b6f4901221)] - **(SEMVER-MINOR)** **fs**: add support for async iterators to `fsPromises.writeFile` (HiroyukiYagihashi) [#37490](https://github.com/nodejs/node/pull/37490)
+* [[`0709cbb7fe`](https://github.com/nodejs/node/commit/0709cbb7fe)] - **(SEMVER-MINOR)** **net**: allow net.BlockList to use net.SocketAddress objects (James M Snell) [#37917](https://github.com/nodejs/node/pull/37917)
+* [[`daa8a7bbcf`](https://github.com/nodejs/node/commit/daa8a7bbcf)] - **(SEMVER-MINOR)** **net**: add SocketAddress class (James M Snell) [#37917](https://github.com/nodejs/node/pull/37917)
+* [[`a4169ce519`](https://github.com/nodejs/node/commit/a4169ce519)] - **(SEMVER-MINOR)** **net**: make net.BlockList cloneable (James M Snell) [#37917](https://github.com/nodejs/node/pull/37917)
+* [[`669b81c68b`](https://github.com/nodejs/node/commit/669b81c68b)] - **(SEMVER-MINOR)** **net,tls**: add abort signal support to connect (Nitzan Uziely) [#37735](https://github.com/nodejs/node/pull/37735)
+* [[`a1123f0a29`](https://github.com/nodejs/node/commit/a1123f0a29)] - **(SEMVER-MINOR)** **readline**: add AbortSignal support to interface (Nitzan Uziely) [#37932](https://github.com/nodejs/node/pull/37932)
+-->
+
+### 주요 변경사항
+
+다음 취약점을 수정했습니다.
+
+* **CVE-2021-3450**: OpenSSL - X509_V_FLAG_X509_STRICT를 사용할 때 CA 인증서 검사의 우회(높음)
+  * 이 OpenSSL 취약점은 Node.js에서 악용될 수 있습니다. 자세한 내용은 <https://www.openssl.org/news/secadv/20210325.txt>에서 볼 수 있습니다.
+  * 영향받는 버전:
+    * 15.x, 14.x, 12.x, 10.x 릴리스 라인의 모든 버전
+* **CVE-2021-3449**: OpenSSL - signature_algorithms 처리 중 NULL 포인터 참조 해제(높음)
+  * 이 OpenSSL 취약점은 Node.js에서 악용될 수 있습니다. 자세한 내용은 <https://www.openssl.org/news/secadv/20210325.txt>에서 볼 수 있습니다.
+  * 영향받는 버전:
+    * 15.x, 14.x, 12.x, 10.x 릴리스 라인의 모든 버전
+* **CVE-2020-7774**: npm 업그레이드 - 프로토타입 오염을 고치려고 y18n을 업데이트함(높음)
+  * y18n npm 모듈의 취약점으로 프로토타입을 오염시켜서 악용될 수 있습니다. 자세한 내용은 <https://github.com/advisories/GHSA-c4w7-xm78-47vh>에서 볼 수 있습니다.
+  * 영향받는 버전:
+    * 14.x, 12.x, 10.x 릴리스 라인의 모든 버전
+
+다른 주요 변경사항
+
+* [[`b6f4901221`](https://github.com/nodejs/node/commit/b6f4901221)] - **(SEMVER-MINOR)** **fs**: add support for async iterators to `fsPromises.writeFile` (HiroyukiYagihashi) [#37490](https://github.com/nodejs/node/pull/37490)
+* [[`0709cbb7fe`](https://github.com/nodejs/node/commit/0709cbb7fe)] - **(SEMVER-MINOR)** **net**: allow net.BlockList to use net.SocketAddress objects (James M Snell) [#37917](https://github.com/nodejs/node/pull/37917)
+* [[`daa8a7bbcf`](https://github.com/nodejs/node/commit/daa8a7bbcf)] - **(SEMVER-MINOR)** **net**: add SocketAddress class (James M Snell) [#37917](https://github.com/nodejs/node/pull/37917)
+* [[`a4169ce519`](https://github.com/nodejs/node/commit/a4169ce519)] - **(SEMVER-MINOR)** **net**: make net.BlockList cloneable (James M Snell) [#37917](https://github.com/nodejs/node/pull/37917)
+* [[`669b81c68b`](https://github.com/nodejs/node/commit/669b81c68b)] - **(SEMVER-MINOR)** **net,tls**: add abort signal support to connect (Nitzan Uziely) [#37735](https://github.com/nodejs/node/pull/37735)
+* [[`a1123f0a29`](https://github.com/nodejs/node/commit/a1123f0a29)] - **(SEMVER-MINOR)** **readline**: add AbortSignal support to interface (Nitzan Uziely) [#37932](https://github.com/nodejs/node/pull/37932)
+
+### Commits
+
+* [[`ac69b95e47`](https://github.com/nodejs/node/commit/ac69b95e47)] - **crypto**: use correct webcrypto RSASSA-PKCS1-v1\_5 algorithm name (Filip Skokan) [#38029](https://github.com/nodejs/node/pull/38029)
+* [[`960c6be229`](https://github.com/nodejs/node/commit/960c6be229)] - **crypto**: add buffering to randomInt (Tobias Nießen) [#35110](https://github.com/nodejs/node/pull/35110)
+* [[`4ef102d34e`](https://github.com/nodejs/node/commit/4ef102d34e)] - **deps**: update to cjs-module-lexer@1.1.1 (Guy Bedford) [#37992](https://github.com/nodejs/node/pull/37992)
+* [[`f0e77149a4`](https://github.com/nodejs/node/commit/f0e77149a4)] - **deps**: update archs files for OpenSSL-1.1.1k (Hassaan Pasha) [#37916](https://github.com/nodejs/node/pull/37916)
+* [[`bbdcdad2c6`](https://github.com/nodejs/node/commit/bbdcdad2c6)] - **deps**: upgrade openssl sources to 1.1.1k+quic (Hassaan Pasha) [#37916](https://github.com/nodejs/node/pull/37916)
+* [[`913ec56798`](https://github.com/nodejs/node/commit/913ec56798)] - **deps**: cjs-module-lexer: cherry-pick 22093e765f (pezhmanparsaee) [#37895](https://github.com/nodejs/node/pull/37895)
+* [[`afc6ab2122`](https://github.com/nodejs/node/commit/afc6ab2122)] - **doc**: fix asyncLocalStorage.run() description (Darkripper214) [#38023](https://github.com/nodejs/node/pull/38023)
+* [[`b40d35d649`](https://github.com/nodejs/node/commit/b40d35d649)] - **doc**: document how to unref stdin when using readline.Interface (Anu Pasumarthy) [#38019](https://github.com/nodejs/node/pull/38019)
+* [[`ce14080473`](https://github.com/nodejs/node/commit/ce14080473)] - **doc**: move psmarshall to collaborators emeriti (Peter Marshall) [#37994](https://github.com/nodejs/node/pull/37994)
+* [[`ae70aa3c63`](https://github.com/nodejs/node/commit/ae70aa3c63)] - **doc**: add distinctive color for code elements inside links (Antoine du Hamel) [#37950](https://github.com/nodejs/node/pull/37950)
+* [[`8792c7c96b`](https://github.com/nodejs/node/commit/8792c7c96b)] - **doc**: add missing events.on metadata (Anna Henningsen) [#37965](https://github.com/nodejs/node/pull/37965)
+* [[`a57dc06adf`](https://github.com/nodejs/node/commit/a57dc06adf)] - **doc**: improve Buffer's encoding documentation (Michaël Zasso) [#37945](https://github.com/nodejs/node/pull/37945)
+* [[`f3fabb57cf`](https://github.com/nodejs/node/commit/f3fabb57cf)] - **doc**: add missing cleanup step in OpenSSL upgrade (Tobias Nießen) [#37927](https://github.com/nodejs/node/pull/37927)
+* [[`13c3924af8`](https://github.com/nodejs/node/commit/13c3924af8)] - **doc**: add Windows-specific info to subprocess.kill() (João Lucas Lucchetta) [#34867](https://github.com/nodejs/node/pull/34867)
+* [[`b6f4901221`](https://github.com/nodejs/node/commit/b6f4901221)] - **(SEMVER-MINOR)** **fs**: add support for async iterators to `fsPromises.writeFile` (HiroyukiYagihashi) [#37490](https://github.com/nodejs/node/pull/37490)
+* [[`ad7e34446c`](https://github.com/nodejs/node/commit/ad7e34446c)] - **fs**: fix chown abort (Darshan Sen) [#38004](https://github.com/nodejs/node/pull/38004)
+* [[`d86aca9a77`](https://github.com/nodejs/node/commit/d86aca9a77)] - **http**: optimize debug function correctly (Michaël Zasso) [#37966](https://github.com/nodejs/node/pull/37966)
+* [[`062541aae5`](https://github.com/nodejs/node/commit/062541aae5)] - **http2**: add specific error code for custom frames (Anna Henningsen) [#37936](https://github.com/nodejs/node/pull/37936)
+* [[`8525231902`](https://github.com/nodejs/node/commit/8525231902)] - **lib**: change wording in lib/domain.js comment (Akhil Marsonya) [#37933](https://github.com/nodejs/node/pull/37933)
+* [[`21e399be4c`](https://github.com/nodejs/node/commit/21e399be4c)] - **lib**: change wording in lib/internal/child\_process comment (Akhil Marsonya) [#37903](https://github.com/nodejs/node/pull/37903)
+* [[`3ab9619e56`](https://github.com/nodejs/node/commit/3ab9619e56)] - **module**: improve error message for invalid data URL (Antoine du Hamel) [#37701](https://github.com/nodejs/node/pull/37701)
+* [[`0709cbb7fe`](https://github.com/nodejs/node/commit/0709cbb7fe)] - **(SEMVER-MINOR)** **net**: allow net.BlockList to use net.SocketAddress objects (James M Snell) [#37917](https://github.com/nodejs/node/pull/37917)
+* [[`daa8a7bbcf`](https://github.com/nodejs/node/commit/daa8a7bbcf)] - **(SEMVER-MINOR)** **net**: add SocketAddress class (James M Snell) [#37917](https://github.com/nodejs/node/pull/37917)
+* [[`a4169ce519`](https://github.com/nodejs/node/commit/a4169ce519)] - **(SEMVER-MINOR)** **net**: make net.BlockList cloneable (James M Snell) [#37917](https://github.com/nodejs/node/pull/37917)
+* [[`669b81c68b`](https://github.com/nodejs/node/commit/669b81c68b)] - **(SEMVER-MINOR)** **net,tls**: add abort signal support to connect (Nitzan Uziely) [#37735](https://github.com/nodejs/node/pull/37735)
+* [[`a94cc27cbe`](https://github.com/nodejs/node/commit/a94cc27cbe)] - **path**: refactor to use more primordials (Akhil Marsonya) [#37893](https://github.com/nodejs/node/pull/37893)
+* [[`6cc1e15669`](https://github.com/nodejs/node/commit/6cc1e15669)] - **readline**: fix pre-aborted signal question handling (Nitzan Uziely) [#37929](https://github.com/nodejs/node/pull/37929)
+* [[`a1123f0a29`](https://github.com/nodejs/node/commit/a1123f0a29)] - **(SEMVER-MINOR)** **readline**: add AbortSignal support to interface (Nitzan Uziely) [#37932](https://github.com/nodejs/node/pull/37932)
+* [[`629e72e9f4`](https://github.com/nodejs/node/commit/629e72e9f4)] - **src**: fix typo in node\_mutex (Tobias Nießen) [#38011](https://github.com/nodejs/node/pull/38011)
+* [[`e61cc0bfb0`](https://github.com/nodejs/node/commit/e61cc0bfb0)] - **src**: fix typos in crypto comments (Tobias Nießen) [#38024](https://github.com/nodejs/node/pull/38024)
+* [[`6ad0b6f0f5`](https://github.com/nodejs/node/commit/6ad0b6f0f5)] - **src**: fix error handling for CryptoJob::ToResult (Tobias Nießen) [#37076](https://github.com/nodejs/node/pull/37076)
+* [[`3175559bed`](https://github.com/nodejs/node/commit/3175559bed)] - **test**: add extra space in test failure output (Qingyu Deng) [#37957](https://github.com/nodejs/node/pull/37957)
+* [[`0243376cfc`](https://github.com/nodejs/node/commit/0243376cfc)] - **test**: use faster variant for rss (Pooja D P) [#36839](https://github.com/nodejs/node/pull/36839)
+* [[`b02c352ad6`](https://github.com/nodejs/node/commit/b02c352ad6)] - **test**: fix test-tls-no-sslv3 for OpenSSL 3 (Richard Lau) [#38027](https://github.com/nodejs/node/pull/38027)
+* [[`0db1a1eacf`](https://github.com/nodejs/node/commit/0db1a1eacf)] - **test**: deflake test-fs-read-optional-params (Luigi Pinca) [#37991](https://github.com/nodejs/node/pull/37991)
+* [[`4d50975cd7`](https://github.com/nodejs/node/commit/4d50975cd7)] - **test**: improve clarity of ALS-enable-disable.js (Darkripper214) [#38008](https://github.com/nodejs/node/pull/38008)
+* [[`5e15ae05d0`](https://github.com/nodejs/node/commit/5e15ae05d0)] - **test**: add DataView test case for v8 serdes (Rich Trott) [#37955](https://github.com/nodejs/node/pull/37955)
+* [[`6d28a24f1c`](https://github.com/nodejs/node/commit/6d28a24f1c)] - **tools**: update ESLint to 7.23.0 (Luigi Pinca) [#37979](https://github.com/nodejs/node/pull/37979)
+* [[`51e7a33d54`](https://github.com/nodejs/node/commit/51e7a33d54)] - **tools,doc**: add "legacy" badge in the TOC (Antoine du Hamel) [#37949](https://github.com/nodejs/node/pull/37949)
+* [[`570fbcef93`](https://github.com/nodejs/node/commit/570fbcef93)] - **url**: forbid pipe in URL host (Darshan Sen) [#37877](https://github.com/nodejs/node/pull/37877)
+
+Windows 32-bit Installer: https://nodejs.org/dist/v15.14.0/node-v15.14.0-x86.msi<br>
+Windows 64-bit Installer: *Coming soon*<br>
+Windows 32-bit Binary: https://nodejs.org/dist/v15.14.0/win-x86/node.exe<br>
+Windows 64-bit Binary: https://nodejs.org/dist/v15.14.0/win-x64/node.exe<br>
+macOS 64-bit Installer: https://nodejs.org/dist/v15.14.0/node-v15.14.0.pkg<br>
+macOS 64-bit Binary: https://nodejs.org/dist/v15.14.0/node-v15.14.0-darwin-x64.tar.gz<br>
+Linux 64-bit Binary: https://nodejs.org/dist/v15.14.0/node-v15.14.0-linux-x64.tar.xz<br>
+Linux PPC LE 64-bit Binary: https://nodejs.org/dist/v15.14.0/node-v15.14.0-linux-ppc64le.tar.xz<br>
+Linux s390x 64-bit Binary: https://nodejs.org/dist/v15.14.0/node-v15.14.0-linux-s390x.tar.xz<br>
+AIX 64-bit Binary: https://nodejs.org/dist/v15.14.0/node-v15.14.0-aix-ppc64.tar.gz<br>
+ARMv7 32-bit Binary: https://nodejs.org/dist/v15.14.0/node-v15.14.0-linux-armv7l.tar.xz<br>
+ARMv8 64-bit Binary: https://nodejs.org/dist/v15.14.0/node-v15.14.0-linux-arm64.tar.xz<br>
+Source Code: *Coming soon*<br>
+Other release files: https://nodejs.org/dist/v15.14.0/<br>
+Documentation: https://nodejs.org/docs/v15.14.0/api/
+
+### SHASUMS
+
+```
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA256
+
+cb133ef05eb9c20c23a2f267f216dca0a66166bb5cdbf1a1871c114a439f8767  node-v15.14.0-aix-ppc64.tar.gz
+a3ea5f2da4868de1513664de76ce09cc8234312a0918223b19e40d3ca4890bf2  node-v15.14.0-darwin-x64.tar.gz
+f355aeda5049fdbac4acca23a7bb6f66e145a179a52bd2489e3f76fbe0feb161  node-v15.14.0-darwin-x64.tar.xz
+fa591c23cb61cb91f09df6ffaebd68dce470073749e5e924e5f3436fbc121132  node-v15.14.0-headers.tar.gz
+147c7d622b185cabb7304f80a74a78a1b21a06eecdd2caf5f56fbf07a816d680  node-v15.14.0-headers.tar.xz
+6d5e0074fe4a45d444bc581aa1fd7ce7081b8491b0f785414a6e5cc30c42854a  node-v15.14.0-linux-arm64.tar.gz
+23108e22efd5b9684ffe357ef25605aba9abc9dd4c6f29f34d0a4680f29ffb45  node-v15.14.0-linux-arm64.tar.xz
+1cef461a73a124dd3f212e2b8230638f4d16b5cc0915425ffad8aabac050d9fb  node-v15.14.0-linux-armv7l.tar.gz
+3636dfdfeedf11c76486692ea8730dfb585f4a7846512e4cb9fc4b725d61cb25  node-v15.14.0-linux-armv7l.tar.xz
+ad286636152e4ba060d2e13eccb166eb8eda8dda04a39ce76f026e9127e90137  node-v15.14.0-linux-ppc64le.tar.gz
+f8870a4716f6bfe7ffbb34f0a16abe56bea83761cbca0b856dc45b7fb0268f02  node-v15.14.0-linux-ppc64le.tar.xz
+20dcd3f97e4c72dfbdc0eaaa8301caf50e2204601559797270062e3d6fefabf5  node-v15.14.0-linux-s390x.tar.gz
+f9a6129724e7a48c6719e21081e6bb09adc0dcc88067a34d8c1084f6c096e6c7  node-v15.14.0-linux-s390x.tar.xz
+23f8adb7afbd9969f0f9b8b2da0ba3e0a9db57c547aa0c5e0885f0b2aae6081c  node-v15.14.0-linux-x64.tar.gz
+f40a52c77a5a98203d24d6e5213c1a189bfc9736d0d9f667cb61151e9431b2a8  node-v15.14.0-linux-x64.tar.xz
+2900b61708fb27679f4c92619752790b78587ece5a6c2a4e6946b810ea93250e  node-v15.14.0.pkg
+f3a35c1b29b58846575085fdee7774d78b75ff4cf1e52572afce7f38685b159a  node-v15.14.0.tar.gz
+8122dc4eea4f00af32a1d14ca85a1d4d6ca7b2dcffd9a731bda149fc5593a66e  node-v15.14.0.tar.xz
+30bb88b225e3138e8dff60cc8cf6c815ec9b7680933cede18d7ed3a947efcb41  node-v15.14.0-win-x64.7z
+efd8d6fba2030d97172a693c05ed4fc446ca5b2258ef2fa6f03f32abb402f036  node-v15.14.0-win-x64.zip
+741a0e9a93ff12d08fdfb661fa44ebd155d626d853016fd7eb6815d3c09fbbbb  node-v15.14.0-win-x86.7z
+192905800143973a5499985b418deff121d42087f8afc68e986ab0ad5baea741  node-v15.14.0-win-x86.zip
+fa460c0483126bad8296be312f23bdc8c8baf0974f512427b1c90846971af29f  node-v15.14.0-x64.msi
+d22b24e8fe60b6d730f9241c36b0f6b1a34b735eece478dd24c0792e2576c1c8  node-v15.14.0-x86.msi
+225c8dd246f110d8939e2bd9c3b86704375d7ee644f575119d5bf0c3a730ac92  win-x64/node.exe
+cef6b29471f8faa5291be30c049822267cfcfe3437c2d724d720b01f6480a827  win-x64/node.lib
+9c3bda01748f88b5ecc35b16ffd5ff21d93cecf8b5729f181bed9536ae69dab8  win-x64/node_pdb.7z
+a4a119e72529eeadee8fe367663b5761a7b5979ccf77abd3da097870b5e50fb5  win-x64/node_pdb.zip
+fc1bced2ecc0ccd3b33c60e3b8230cdb48feae75c5a45ae241f27e12da310825  win-x86/node.exe
+889e03560e730464fe438f9b167e0907b61d1d47a19d05ede27e68c5da136991  win-x86/node.lib
+59de7e99d800e474df2b6bc287d18f85f2e4e471897792b40f7b86cd09f38208  win-x86/node_pdb.7z
+c1daba7b20b6990382467dcbceb72f980dd4d6ae11f67c85a244ef65400cd565  win-x86/node_pdb.zip
+-----BEGIN PGP SIGNATURE-----
+
+iQEzBAEBCAAdFiEEDv/hvO/ZyE49CYFSkzsB9AtcqUYFAmBsyXAACgkQkzsB9Atc
+qUaU6wgAthF8ouuSj6Ag9n/0i+DMbdYnTcLsLFbtlPdUgjPCRvxjivqH2GqO7jXq
+8WKuHxj9sqKP4t+hdujbWqEY/Oj4RsHT3h4NARlREjl2ZKCKt27rPJpqcHjS3D1x
+xS7tEOSJ9flq2fddXOFHYPkK5FH9s4kaXtpDywnb4UiEmO1mKICO5yhJt8NYEKlN
+67+d/u17Pmgo3YgqMpa4IT+u1oy1XkiLwiBfkZmUtmYLFrLtwbYAalhoCn4HDOyj
+JWie/9fK/A9lcfFtB6xLC2mudDBpQM4YSbON1gh7VriLpKPz4mjK6TpkNfxpAeii
+1BbOrsrDwXoTWnxH4QpmQCXYY7N/iw==
+=oRXA
+-----END PGP SIGNATURE-----
+
+```


### PR DESCRIPTION
#1091 에서 한 보안 릴리스가 업데이트 되어서 수정했습니다. 예전엔 본문을 남겨놨는데 이번에 오니까 원래의 공지는 지우고 업데이트된 내용만 남겨두네요. 여기서는 이전에 번역했던 것은 아래에 그대로 두고 업데이트 부분을 추가했습니다. 

close #1096 
close #1097
close #1098 
close #1099 
