### PR TITLE
scaffold accepts original URL instead raw URL

### DIFF
--- a/bin/scaffold.mjs
+++ b/bin/scaffold.mjs
@@ -16,12 +16,7 @@ function main() {
     return;
   }
 
-  const urlDelimiter = '/en/blog/';
-  let urlPostfix = URL.split(urlDelimiter)[1];
-  if (urlPostfix.endsWith('/')) {
-    urlPostfix = urlPostfix.substr(0, urlPostfix.length - 1);
-  }
-  const rawURL = `https://raw.githubusercontent.com/nodejs/nodejs.org/master/locale${urlDelimiter}${urlPostfix}.md`;
+  const rawURL = URL.replace(/^https:\/\/nodejs.org(\/en\/blog\/.+?)\/?$/, "https://raw.githubusercontent.com/nodejs/nodejs.org/master/locale$1.md")
 
   if (isWeeklyUpdate(rawURL) && !DATE) {
     console.error(`🚨  주간 뉴스 외에는 url 뒤에 발행 일자를 전달해야 합니다.`);

--- a/bin/scaffold.mjs
+++ b/bin/scaffold.mjs
@@ -9,20 +9,27 @@ import { __ } from './translate.mjs';
 function main() {
   const [URL, DATE] = process.argv.slice(2);
   const POST_PATH = path.resolve('source', '_posts');
-  
+
   if (!URL) {
-    console.error(`🚨  번역문서의 GitHub raw URL이 필요합니다.`);
+    console.error(`🚨  번역할 nodejs.org의 블로그 글 URL이 필요합니다.`);
     printGuide();
     return;
   }
 
-  if (isWeeklyUpdate(URL) && !DATE) {
+  const urlDelimiter = '/en/blog/';
+  let urlPostfix = URL.split(urlDelimiter)[1];
+  if (urlPostfix.endsWith('/')) {
+    urlPostfix = urlPostfix.substr(0, urlPostfix.length - 1);
+  }
+  const rawURL = `https://raw.githubusercontent.com/nodejs/nodejs.org/master/locale${urlDelimiter}${urlPostfix}.md`;
+
+  if (isWeeklyUpdate(rawURL) && !DATE) {
     console.error(`🚨  주간 뉴스 외에는 url 뒤에 발행 일자를 전달해야 합니다.`);
     printGuide();
     return;
   }
   
-  const fileName = getFileName(URL, DATE);
+  const fileName = getFileName(rawURL, DATE);
   if (!fileName) {
     console.error(`🚨  지원하지 않는 형식의 URL입니다.`);
     printGuide();
@@ -36,9 +43,9 @@ function main() {
   
   const filePath = `${POST_PATH}/${fileName}`;
   
-  get(URL, resp => {
+  get(rawURL, resp => {
     resp
-      .pipe(transformer(URL))
+      .pipe(transformer(rawURL))
       .pipe(createWriteStream(filePath));
 
     console.log(`✅ 번역 파일이 생성되었습니다: ${filePath}`);


### PR DESCRIPTION
이슈를 등록할 때 <https://nodejs.org/en/blog/release/v15.14.0/> 같은 URL의 Raw URL인 <https://raw.githubusercontent.com/nodejs/nodejs.org/master/locale/en/blog/release/v15.14.0.md>를 매번 찾아서 올리는게 불편해서 블로그 URL롤 스캐폴딩을 하면 알아서 raw URL을 찾도록 수정했습니다.

어차피 폴터 패턴이라 항상 똑같아서요. 