### PR TITLE
deps: bump hexo-cli from 4.2.0 to 4.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "chalk": "^1.1.3",
         "hexo": "^5.2.0",
-        "hexo-cli": "^4.2.0",
+        "hexo-cli": "^4.3.0",
         "hexo-deployer-git": "^3.0.0",
         "hexo-generator-alias": "^0.1.3",
         "hexo-generator-archive": "^0.1.4",
@@ -793,61 +793,54 @@
       }
     },
     "node_modules/dom-serializer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.2.0.tgz",
-      "integrity": "sha512-n6kZFH/KlCrqs/1GHMOd5i2fd/beQHuehKdWvNNffbGHTr/almdhuVvTVFb3V7fglz+nC50fFusu3lY33h12pA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
       "dependencies": {
         "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
+        "domhandler": "^4.2.0",
         "entities": "^2.0.0"
-      }
-    },
-    "node_modules/dom-serializer/node_modules/domhandler": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
-      "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
-      "dependencies": {
-        "domelementtype": "^2.1.0"
       },
-      "engines": {
-        "node": ">= 4"
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
     "node_modules/domelementtype": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
-      "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
     },
     "node_modules/domhandler": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
-      "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+      "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
       "dependencies": {
-        "domelementtype": "^2.0.1"
+        "domelementtype": "^2.2.0"
       },
       "engines": {
         "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
     "node_modules/domutils": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.4.tgz",
-      "integrity": "sha512-jBC0vOsECI4OMdD0GC9mGn7NXPLb+Qt6KW1YDQzeQYRUFKmNG8lh7mO5HiELfr+lLQE7loDVI4QcAxV80HS+RA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+      "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
       "dependencies": {
         "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0"
-      }
-    },
-    "node_modules/domutils/node_modules/domhandler": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
-      "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
-      "dependencies": {
-        "domelementtype": "^2.1.0"
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
       },
-      "engines": {
-        "node": ">= 4"
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/ee-first": {
@@ -874,7 +867,10 @@
     "node_modules/entities": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -1197,9 +1193,9 @@
       }
     },
     "node_modules/hexo-cli": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hexo-cli/-/hexo-cli-4.2.0.tgz",
-      "integrity": "sha512-NJQYKnD41KUlNZzEyi8wDzPeGhrjwLLTa05dtkwq+lJch+j9idZTh4dgn3w/82o6Q/zygn+ibO1XvihMfFdSfw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/hexo-cli/-/hexo-cli-4.3.0.tgz",
+      "integrity": "sha512-lr46h1tK1RNQJAQZbzKYAWGsmqF5DLrW6xKEakqv/o9JqgdeempBjIm7HqjcZEUBpWij4EO65X6YJiDmT9LR7g==",
       "dependencies": {
         "abbrev": "^1.1.1",
         "bluebird": "^3.5.5",
@@ -1544,22 +1540,21 @@
       }
     },
     "node_modules/hexo-util": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/hexo-util/-/hexo-util-2.4.0.tgz",
-      "integrity": "sha512-IPQvAyn0cznYMU2gskMiZ6LZEvN7wHNusrJoYxrir4f7S7POpZeDTBswiko9R1qqd+/hu07wUYZdm4ceTTCEaA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hexo-util/-/hexo-util-2.5.0.tgz",
+      "integrity": "sha512-l0zkqcg2524KPO84HQe0JROpPlCM/dEnCJaJrZ1qsq+3+/YxhDa0zxiGtUVY1dtrWzOK/V11Zj+UEklhGP8Jeg==",
       "dependencies": {
         "bluebird": "^3.5.2",
         "camel-case": "^4.0.0",
         "cross-spawn": "^7.0.0",
         "deepmerge": "^4.2.2",
-        "highlight.js": "^10.0.0",
-        "htmlparser2": "^4.0.0",
+        "highlight.js": "^10.7.1",
+        "htmlparser2": "^6.0.0",
         "prismjs": "^1.17.1",
-        "strip-indent": "^3.0.0",
-        "striptags": "^3.1.1"
+        "strip-indent": "^3.0.0"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=12.4.0"
       }
     },
     "node_modules/hexo/node_modules/ansi-regex": {
@@ -1616,9 +1611,9 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.5.0.tgz",
-      "integrity": "sha512-xTmvd9HiIHR6L53TMC7TKolEj65zG1XU+Onr8oi86mYa+nLcIbxTTWkpW7CsEwv/vK7u1zb8alZIMLDqqN6KTw==",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
       "engines": {
         "node": "*"
       }
@@ -1629,13 +1624,20 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
     "node_modules/htmlparser2": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
-      "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
       "dependencies": {
         "domelementtype": "^2.0.1",
-        "domhandler": "^3.0.0",
-        "domutils": "^2.0.0",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
         "entities": "^2.0.0"
       }
     },
@@ -3482,11 +3484,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/striptags": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.1.1.tgz",
-      "integrity": "sha1-yMPn/db7S7OjKjt1LltePjgJPr0="
-    },
     "node_modules/structured-source": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-3.0.2.tgz",
@@ -4672,56 +4669,36 @@
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "dom-serializer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.2.0.tgz",
-      "integrity": "sha512-n6kZFH/KlCrqs/1GHMOd5i2fd/beQHuehKdWvNNffbGHTr/almdhuVvTVFb3V7fglz+nC50fFusu3lY33h12pA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
       "requires": {
         "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
+        "domhandler": "^4.2.0",
         "entities": "^2.0.0"
-      },
-      "dependencies": {
-        "domhandler": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
-          "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
-          "requires": {
-            "domelementtype": "^2.1.0"
-          }
-        }
       }
     },
     "domelementtype": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
-      "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
     },
     "domhandler": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
-      "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+      "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
       "requires": {
-        "domelementtype": "^2.0.1"
+        "domelementtype": "^2.2.0"
       }
     },
     "domutils": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.4.tgz",
-      "integrity": "sha512-jBC0vOsECI4OMdD0GC9mGn7NXPLb+Qt6KW1YDQzeQYRUFKmNG8lh7mO5HiELfr+lLQE7loDVI4QcAxV80HS+RA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+      "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
       "requires": {
         "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0"
-      },
-      "dependencies": {
-        "domhandler": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
-          "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
-          "requires": {
-            "domelementtype": "^2.1.0"
-          }
-        }
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
       }
     },
     "ee-first": {
@@ -5030,9 +5007,9 @@
       }
     },
     "hexo-cli": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hexo-cli/-/hexo-cli-4.2.0.tgz",
-      "integrity": "sha512-NJQYKnD41KUlNZzEyi8wDzPeGhrjwLLTa05dtkwq+lJch+j9idZTh4dgn3w/82o6Q/zygn+ibO1XvihMfFdSfw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/hexo-cli/-/hexo-cli-4.3.0.tgz",
+      "integrity": "sha512-lr46h1tK1RNQJAQZbzKYAWGsmqF5DLrW6xKEakqv/o9JqgdeempBjIm7HqjcZEUBpWij4EO65X6YJiDmT9LR7g==",
       "requires": {
         "abbrev": "^1.1.1",
         "bluebird": "^3.5.5",
@@ -5310,25 +5287,24 @@
       }
     },
     "hexo-util": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/hexo-util/-/hexo-util-2.4.0.tgz",
-      "integrity": "sha512-IPQvAyn0cznYMU2gskMiZ6LZEvN7wHNusrJoYxrir4f7S7POpZeDTBswiko9R1qqd+/hu07wUYZdm4ceTTCEaA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hexo-util/-/hexo-util-2.5.0.tgz",
+      "integrity": "sha512-l0zkqcg2524KPO84HQe0JROpPlCM/dEnCJaJrZ1qsq+3+/YxhDa0zxiGtUVY1dtrWzOK/V11Zj+UEklhGP8Jeg==",
       "requires": {
         "bluebird": "^3.5.2",
         "camel-case": "^4.0.0",
         "cross-spawn": "^7.0.0",
         "deepmerge": "^4.2.2",
-        "highlight.js": "^10.0.0",
-        "htmlparser2": "^4.0.0",
+        "highlight.js": "^10.7.1",
+        "htmlparser2": "^6.0.0",
         "prismjs": "^1.17.1",
-        "strip-indent": "^3.0.0",
-        "striptags": "^3.1.1"
+        "strip-indent": "^3.0.0"
       }
     },
     "highlight.js": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.5.0.tgz",
-      "integrity": "sha512-xTmvd9HiIHR6L53TMC7TKolEj65zG1XU+Onr8oi86mYa+nLcIbxTTWkpW7CsEwv/vK7u1zb8alZIMLDqqN6KTw=="
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
     },
     "hosted-git-info": {
       "version": "2.8.9",
@@ -5336,13 +5312,13 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
     "htmlparser2": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
-      "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
       "requires": {
         "domelementtype": "^2.0.1",
-        "domhandler": "^3.0.0",
-        "domutils": "^2.0.0",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
         "entities": "^2.0.0"
       }
     },
@@ -6773,11 +6749,6 @@
       "requires": {
         "min-indent": "^1.0.0"
       }
-    },
-    "striptags": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.1.1.tgz",
-      "integrity": "sha1-yMPn/db7S7OjKjt1LltePjgJPr0="
     },
     "structured-source": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "hexo": "^5.2.0",
-    "hexo-cli": "^4.2.0",
+    "hexo-cli": "^4.3.0",
     "hexo-deployer-git": "^3.0.0",
     "hexo-generator-alias": "^0.1.3",
     "hexo-generator-archive": "^0.1.4",


### PR DESCRIPTION
This addresses https://github.com/advisories/GHSA-qxg5-2qff-p49r because
hexo-cli@4.3.0 no longer has striptags as a dependency.